### PR TITLE
Corrected the  better-auth-adaptor.mdx

### DIFF
--- a/developer-resources/better-auth-adaptor.mdx
+++ b/developer-resources/better-auth-adaptor.mdx
@@ -61,7 +61,7 @@ Never commit API keys or secrets to version control.
 Create or update <code>src/lib/auth.ts</code>:
 
 ```typescript expandable
-import { BetterAuth } from "better-auth";
+import { betterAuth } from "better-auth";
 import {
   dodopayments,
   checkout,


### PR DESCRIPTION
Changed the better-auth adapter docs to include the correct import.
It was previously {BetterAuth}, instead should be {betterAuth}.