### PR TITLE
add wrap, unwrap info for webhook verification

### DIFF
--- a/developer-resources/webhooks.mdx
+++ b/developer-resources/webhooks.mdx
@@ -165,16 +165,31 @@ To ensure the security of your webhooks, always validate the payloads and use HT
 
 ### Verifying Signatures
 
-Each webhook request includes a `webhook-signature` header -- an HMAC SHA256 signature of the webhook payload and timestamp, signed with your secret key.
-To verify a webhook came from DodoPayments:
+Each webhook request includes a `webhook-signature` header, an HMAC SHA256 signature of the webhook payload and timestamp, signed with your secret key.
 
-1. Compute the HMAC SHA256 of this string using your webhook secret key obtained from the DodoPayments Dashboard
-2. Concatenate the `webhook-id`, `webhook-timestamp`, and stringified `payload` values from the webhook with periods (`.`)  
-The respective payloads for outgoing webhooks can be found in the [Webhook Payload](/developer-resources/webhooks/intents/payment).
+#### SDK verification (recommended)
 
-3. Compare the computed signature to the received `webhook-signature` header value. If they match, the webhook is authentic.
+All official SDKs include built‑in helpers to securely validate and parse incoming webhooks. Two methods are available:
 
-Since we follow the Standard Webhooks specification, you can use one of their libraries to verify the signature: https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries
+- `unwrap()`: Verifies signatures using your webhook secret key
+- `unsafe_unwrap()`: Parses payloads without verification
+
+<Tip>
+Provide your webhook secret via `DODO_PAYMENTS_WEBHOOK_KEY` when initializing the Dodo Payments client.
+</Tip>
+
+
+#### Manual verification (alternative)
+
+If you are not using an SDK, you can verify signatures yourself following the Standard Webhooks spec:
+
+1. Build the signed message by concatenating `webhook-id`, `webhook-timestamp`, and the exact raw stringified `payload`, separated by periods (`.`).
+2. Compute the HMAC SHA256 of that string using your webhook secret key from the Dashboard.
+3. Compare the computed signature to the `webhook-signature` header. If they match, the webhook is authentic.
+
+<Info>
+We follow the Standard Webhooks specification. You can use their libraries to verify signatures: https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries. For event payload formats, see the [Webhook Payload](/developer-resources/webhooks/intents/payment).
+</Info>
 
 ### Responding to Webhooks
 - Your webhook handler must return a `2xx status code` to acknowledge receipt of the event.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Expanded webhook signature verification guidance with recommended SDK-based approach and manual verification alternative
- Added configuration tips for providing webhook secrets and references to verification libraries
- Clarified webhook response handling behavior for non-2xx responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->