### PR TITLE
docs: reduce height of email screenshots in recovery pages

### DIFF
--- a/changelog/v0.15.1.mdx
+++ b/changelog/v0.15.1.mdx
@@ -14,7 +14,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v0
 ### Platform Updates
 - Introduced Dodo Payments [Wall of Love](https://dodopayments.com/wall-of-love), showcasing customer testimonials.
 - Added social sharing functionality for successful transactions.
-    <img src="/images/changelog/share-transaction.png" alt="Share Transaction Feature"/>
+    <img src="/images/changelog/share-transaction.png" alt="Share Transaction Feature" style={{ maxHeight: '500px', width: 'auto' }} />
 - Released Policy Generator tool for automatic generation of privacy policy, terms of service, and refund policy documents. [Try Policy Generator](https://dodopayments.com/tools/policy-generator).
 
 ### Documentation Improvements

--- a/changelog/v0.16.1.mdx
+++ b/changelog/v0.16.1.mdx
@@ -8,7 +8,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v0
 ## New Features 🚀
 
 - **Account Summary Feature**: Provides detailed visibility into transaction and payout ledgers.
-    <img src="/images/changelog/account_summary.png" alt="Account Summary" />
+    <img src="/images/changelog/account_summary.png" alt="Account Summary" style={{ maxHeight: '500px', width: 'auto' }} />
 - **Enhanced API Documentation**: Includes comprehensive parameter descriptions and usage examples.
 
 ## Improvements and Bug Fixes 🔧

--- a/changelog/v0.18.0.mdx
+++ b/changelog/v0.18.0.mdx
@@ -8,7 +8,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v0
 ## New Features 🚀
 
 - **AI Chat Support**: Now you can chat with our AI assistant to get help with your technical queries or check the documentation more effectively.
-    <img src="/images/changelog/ai_chat.png" alt="Dodo Payments AI Chat Support" />
+    <img src="/images/changelog/ai_chat.png" alt="Dodo Payments AI Chat Support" style={{ maxHeight: '500px', width: 'auto' }} />
 
 - **Enhanced APIs**: Added APIs to filter payments, refunds, subscriptions, and disputes based on `customer_id`, time period, and status, providing more flexibility in data retrieval.
 

--- a/changelog/v0.22.0.mdx
+++ b/changelog/v0.22.0.mdx
@@ -11,7 +11,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v0
 
 - **UPI QR Payment Method**: Added UPI QR as a payment method for the Indian market, allowing customers to pay using UPI QR codes.
     
-    <img src="/images/changelog/upi-qr.png" alt="UPI QR Feature"/>
+    <img src="/images/changelog/upi-qr.png" alt="UPI QR Feature" style={{ maxHeight: '500px', width: 'auto' }} />
 
 - **Tax ID on Checkout**: Customers can now add their Tax ID on the checkout page for invoicing and tax purposes.
 
@@ -50,7 +50,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v0
 
 - **Centralized Help Widget**: Added a centralized Help widget to streamline and improve support.
     
-    <img src="/images/changelog/help-widget.png" alt="Help Widget"/>
+    <img src="/images/changelog/help-widget.png" alt="Help Widget" style={{ maxHeight: '500px', width: 'auto' }} />
 
 ## Improvements and Bug Fixes 🔧
 

--- a/changelog/v1.10.1.mdx
+++ b/changelog/v1.10.1.mdx
@@ -13,7 +13,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     - Persistent data availability throughout the entire checkout flow
     - More enhancements planned for future releases!
   
-    <Frame><img src="/images/changelog/checkout_2.png" alt="Checkout 2.0"/></Frame>
+    <Frame><img src="/images/changelog/checkout_2.png" alt="Checkout 2.0" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Configurable Payment Methods**: New `allowed_payment_methods` configuration enables merchants to customize available payment options during checkout. See the [Allowed Payment Methods](/features/payment-methods#configuring-payment-methods) documentation for implementation details.
 

--- a/changelog/v1.11.0.mdx
+++ b/changelog/v1.11.0.mdx
@@ -9,15 +9,15 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Address Autofill**: Streamlined checkout process with smart address field auto-completion based on user input.
   
-    <Frame><img src="/images/changelog/address_autofill.png" alt="Address Autofill"/></Frame>
+    <Frame><img src="/images/changelog/address_autofill.png" alt="Address Autofill" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Notifications Center**: Stay informed with a new dedicated notifications tab for important system events and updates.
 
-    <Frame><img src="/images/changelog/notifications.png" alt="Notifications"/></Frame>
+    <Frame><img src="/images/changelog/notifications.png" alt="Notifications" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Payment Link Query Builder**: Create and customize payment links more efficiently with our new visual query builder.
 
-    <Frame><img src="/images/changelog/query_selector.png" alt="Query Builder"/></Frame>
+    <Frame><img src="/images/changelog/query_selector.png" alt="Query Builder" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Saved Payment Methods**: Enable display of previously used payment methods during checkout by setting `show_saved_payment_methods: true` in payment link configuration.
 

--- a/changelog/v1.13.0.mdx
+++ b/changelog/v1.13.0.mdx
@@ -18,7 +18,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     - **Americas**: BRL (Brazilian Real), CAD (Canadian Dollar), MXN (Mexican Peso)
   
     <Frame>
-      <img src="/images/changelog/adaptive_currency.png" alt="Adaptive Currency" />
+      <img src="/images/changelog/adaptive_currency.png" alt="Adaptive Currency" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
 
 - **[Dodo Payments MCP Server](/developer-resources/mcp-server)** 🤖

--- a/changelog/v1.14.0.mdx
+++ b/changelog/v1.14.0.mdx
@@ -14,7 +14,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   - **EPS** - Austria
 
   <Frame>
-    <img alt="Supported European Payment Methods" src="/images/transactions/payments/european.png" />
+    <img alt="Supported European Payment Methods" src="/images/transactions/payments/european.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
   <Note>

--- a/changelog/v1.16.1.mdx
+++ b/changelog/v1.16.1.mdx
@@ -10,7 +10,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 - **Modern Verification Forms**: Redesigned the verification forms with a modern, user-friendly interface featuring clearer instructions, improved visual hierarchy, and intuitive form fields for a smoother verification process.
 
   <Frame>
-    <img alt="Verification Forms" src="/images/changelog/verification_forms.png" />
+    <img alt="Verification Forms" src="/images/changelog/verification_forms.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **New Java and Kotlin SDKs**: Released native SDKs for Java and Kotlin to support Android development and enterprise Java applications. The SDKs include comprehensive documentation, sample code, and full support for Dodo Payments features including payments, subscriptions, and refunds. Available on GitHub: [Java SDK](https://github.com/dodopayments/dodopayments-java) and [Kotlin SDK](https://github.com/dodopayments/dodopayments-kotlin).

--- a/changelog/v1.18.3.mdx
+++ b/changelog/v1.18.3.mdx
@@ -12,13 +12,13 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 - **Enhanced Onboarding Guidance**: Improved sidebar nudges to provide clearer direction on next steps in your Dodo Payments onboarding journey.
 
   <Frame>
-    <img alt="Sidebar Nudges" src="/images/changelog/sidebar-nudges.png" />
+    <img alt="Sidebar Nudges" src="/images/changelog/sidebar-nudges.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Notification Preferences Center**: Added a dedicated section for managing your notification settings. Access it by clicking the bell icon in the top right corner and then selecting the settings icon.
 
   <Frame>
-    <img alt="Notification Preferences" src="/images/changelog/notif-pref.png" />
+    <img alt="Notification Preferences" src="/images/changelog/notif-pref.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Enhanced Adaptive Currency Information**: Added new fields to the payment response including `settlement_amount`, `settlement_currency`, and `settlement_tax` to provide greater transparency on settlement details.

--- a/changelog/v1.21.0.mdx
+++ b/changelog/v1.21.0.mdx
@@ -17,7 +17,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   With addons, you unlock new billing options such as seat-based billing or variable billing per customer. Get creative with addons to design flexible billing models for your business.
 
   <Frame>
-    <img alt="Addons" src="/images/changelog/addons.png" />
+    <img alt="Addons" src="/images/changelog/addons.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Enhanced Dispute Management**: Improved dispute handling to be more robust and easier to manage through your Dodo Payments dashboard.

--- a/changelog/v1.22.0.mdx
+++ b/changelog/v1.22.0.mdx
@@ -15,7 +15,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   - **Navigation**: All pages within the Dodo Payments dashboard
 
   <Frame>
-    <img alt="Unified Dashboard Search" src="/images/changelog/search.png" />
+    <img alt="Unified Dashboard Search" src="/images/changelog/search.png" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Addons Plan Changes**: Added support for upgrading and downgrading subscriptions that include addons.

--- a/changelog/v1.25.0.mdx
+++ b/changelog/v1.25.0.mdx
@@ -15,7 +15,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   - **PCI Compliance**: Maintains security standards while providing an embedded experience
 
   <Frame>
-    <img src="/images/cover-images/overlay-checkout.png" alt="Overlay Checkout Cover Image"/>
+    <img src="/images/cover-images/overlay-checkout.png" alt="Overlay Checkout Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
   Try it out:

--- a/changelog/v1.27.0.mdx
+++ b/changelog/v1.27.0.mdx
@@ -9,7 +9,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Partial Refunds**: We're excited to introduce our new Partial Refunds feature, now available through both our API and Dashboard. This powerful capability allows merchants to process precise refunds for specific components of a payment, whether it's a seat add-on or a portion of a subscription. The feature includes built-in validation to prevent errors and automatically generates refund receipts for your records.
   <Frame>
-    <img src="/images/changelog/partial_refunds.png" alt="Partial Refunds Cover Image"/>
+    <img src="/images/changelog/partial_refunds.png" alt="Partial Refunds Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Multi-Brand Support**: We're launching Multi-Brand Support, enabling you to manage multiple brands and websites under a single verified business account. This feature is ideal for launching new product lines, creating regional microsites, or separating different offerings while maintaining a streamlined operation.
@@ -22,7 +22,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   - **Simplified Payouts**: All revenue consolidates into your existing account without additional verification requirements
 
   <Frame>
-    <img src="/images/changelog/brands.png" alt="Multi-Brand Cover Image"/>
+    <img src="/images/changelog/brands.png" alt="Multi-Brand Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
   To create additional brands, navigate to Business `Settings ▸ Brands ▸ Add Brand` and complete the required details.

--- a/changelog/v1.3.2.mdx
+++ b/changelog/v1.3.2.mdx
@@ -9,10 +9,10 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Teams Feature**: We have introduced the highly requested Teams Feature. Now, you can invite `Editors` and `Viewers` to your Business and collaborate with them seamlessly. To try it out, navigate to the `Business > Teams` section in the Dashboard.
 
-    <Frame><img src="/images/changelog/teams.png" alt="Teams Feature"/></Frame>
+    <Frame><img src="/images/changelog/teams.png" alt="Teams Feature" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Enhanced Success/Failure Screens**: The default success and failure screens have been updated for cases where no `redirect_url` is provided. These screens now offer greater visibility to your customers and include an option to download the invoice.
 
-    <Frame><img src="/images/changelog/new_success.png" alt="Success Screens"/></Frame>
+    <Frame><img src="/images/changelog/new_success.png" alt="Success Screens" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Others**: Minor improvements and bug fixes.

--- a/changelog/v1.30.0.mdx
+++ b/changelog/v1.30.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 - **Custom Payout Threshold**: Added the ability to set minimum payout amounts for USD wallets, helping merchants optimize payout processing and reduce fees for small transactions. Access this feature at `Payouts ▸ USD Wallet ▸ Edit Payout Threshold`.
   
   <Frame>
-    <img src="/images/changelog/payout-threshold.png" alt="Payout Threshold Cover Image"/>
+    <img src="/images/changelog/payout-threshold.png" alt="Payout Threshold Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **API Standardization**: Implemented standardized API error codes and messages as part of our ongoing API improvement initiative. This enhancement makes the API more consistent and developer-friendly. For detailed information, visit our [Error Codes Documentation](/api-reference/error-codes).

--- a/changelog/v1.32.0.mdx
+++ b/changelog/v1.32.0.mdx
@@ -9,7 +9,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Affiliate Program Integration**: Launched integration with Affonso, enabling you to create and manage affiliate programs directly through Dodo Payments. Track referrals, handle commissions, and grow your revenue with trusted affiliate partnerships. Learn more in our [Affiliates](/features/affiliates) documentation.
   <Frame>
-    <img src="/images/affiliates/cover.jpeg" alt="Affiliates Cover Image"/>
+    <img src="/images/affiliates/cover.jpeg" alt="Affiliates Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Multiple Webhook Support**: Enhanced webhook capabilities to support multiple endpoints, allowing you to send event notifications to different systems simultaneously.

--- a/changelog/v1.34.0.mdx
+++ b/changelog/v1.34.0.mdx
@@ -10,7 +10,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 - **Digital Product Delivery**: Streamlined digital product delivery system with automated fulfillment, ensuring customers receive their digital goods immediately after successful payment. Learn more in our [Digital Product Delivery](/features/digital-product-delivery) documentation.
   
   <Frame>
-    <img src="/images/digital-product-delivery/1.png" alt="Digital product delivery configuration interface showing file upload and external link options" />
+    <img src="/images/digital-product-delivery/1.png" alt="Digital product delivery configuration interface showing file upload and external link options" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **React Native SDK (Beta)**: Released our React Native SDK in beta, enabling secure payment processing in native Android and iOS apps with customizable UI components and screens. Learn more in our [React Native SDK](/developer-resources/react-native-integration) documentation.

--- a/changelog/v1.34.4.mdx
+++ b/changelog/v1.34.4.mdx
@@ -19,7 +19,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     - Revenue growth rate analysis
 
     <Frame>
-      <img src="/images/analytics/revenue.png" alt="Revenue Analytics dashboard showing comprehensive revenue metrics and country breakdown" />
+      <img src="/images/analytics/revenue.png" alt="Revenue Analytics dashboard showing comprehensive revenue metrics and country breakdown" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
 
   - **Customer Analytics**
@@ -29,7 +29,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     - Top 6 customers for current month
 
     <Frame>
-      <img src="/images/analytics/customer.png" alt="Customer Analytics dashboard displaying ARPU, customer counts, and top customer rankings" />
+      <img src="/images/analytics/customer.png" alt="Customer Analytics dashboard displaying ARPU, customer counts, and top customer rankings" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
 
   - **Payment Success Rate Analytics**
@@ -40,5 +40,5 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     - Monthly Success Rate trends
 
     <Frame>
-      <img src="/images/analytics/success-rate.png" alt="Payment Success Rate Analytics showing success rates, failure reasons, and monthly trends" />
+      <img src="/images/analytics/success-rate.png" alt="Payment Success Rate Analytics showing success rates, failure reasons, and monthly trends" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>

--- a/changelog/v1.37.0.mdx
+++ b/changelog/v1.37.0.mdx
@@ -23,7 +23,7 @@ Track your recurring revenue metrics with detailed breakdowns:
 - **Net New MRR Chart**: Net revenue impact combining new, expansion, and churn MRR
 
 <Frame>
-  <img src="/images/analytics/revenue-breakdown.png" alt="Revenue Breakdown dashboard showing projected ARR, MRR breakdown, and growth rates" />
+  <img src="/images/analytics/revenue-breakdown.png" alt="Revenue Breakdown dashboard showing projected ARR, MRR breakdown, and growth rates" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 #### Retention Analytics
@@ -36,7 +36,7 @@ Monitor customer retention and churn patterns:
 - **User Retention Matrix**: Cohort analysis showing customer retention rates across different time periods
 
 <Frame>
-  <img src="/images/analytics/retention.png" alt="Retention Analytics dashboard showing customer churn rate, revenue churn rate, and churn rate trends" />
+  <img src="/images/analytics/retention.png" alt="Retention Analytics dashboard showing customer churn rate, revenue churn rate, and churn rate trends" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Reports 2.0
@@ -55,7 +55,7 @@ Available reports include:
 - **Account Summary Report**: Complete account overview and summary
 
 <Frame>
-  <img src="/images/analytics/reports.png" alt="Reports 2.0 dashboard showing various report types" />
+  <img src="/images/analytics/reports.png" alt="Reports 2.0 dashboard showing various report types" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Enhanced Payout Reporting
@@ -63,7 +63,7 @@ Available reports include:
 We've added detailed payout reports that provide clear visibility into fees and transaction details for each payout you receive from Dodo Payments. Access these enhanced reports in **Business > Payouts**.
 
 <Frame>
-  <img src="/images/analytics/payout.png" alt="Payout Report dashboard showing detailed payout information" />
+  <img src="/images/analytics/payout.png" alt="Payout Report dashboard showing detailed payout information" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Dodo Payments Remote MCP Server

--- a/changelog/v1.38.0.mdx
+++ b/changelog/v1.38.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 Share your analytics charts as images with customizable branding options. Click the share button on any chart to generate an image with multiple color variants that match your brand identity.
 
 <Frame>
-  <img src="/images/changelog/share-chart.png" alt="Analytics chart sharing interface showing share button and color variant options" />
+  <img src="/images/changelog/share-chart.png" alt="Analytics chart sharing interface showing share button and color variant options" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Multiple Partial Refunds
@@ -24,7 +24,7 @@ Process multiple partial refunds for a single payment through both the API and D
 Track your business growth with new cumulative revenue charts in the analytics dashboard, offering comprehensive insights into your revenue trends over time.
 
 <Frame>
-  <img src="/images/changelog/revenue-chart.png" alt="Cumulative revenue charts displaying revenue growth trends" />
+  <img src="/images/changelog/revenue-chart.png" alt="Cumulative revenue charts displaying revenue growth trends" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Next.js Adapter

--- a/changelog/v1.4.0.mdx
+++ b/changelog/v1.4.0.mdx
@@ -9,7 +9,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Storefront Feature**: Create a simple, branded, and mobile-friendly online store to showcase both One-Time Payment products and Subscription products. This feature eliminates the complexity of building an entire website, enabling you to quickly offer your products or services online without additional web development efforts.
 
-    <Frame><img src="/images/store-front/sf-1.png"/></Frame>
+    <Frame><img src="/images/store-front/sf-1.png" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Amazon Pay Integration**: Added Amazon Pay as a payment method for One-Time Payments.
 

--- a/changelog/v1.47.0.mdx
+++ b/changelog/v1.47.0.mdx
@@ -15,14 +15,14 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
   - **UI & Style Updates:** Refined colors, typography, and spacing deliver a cleaner, more consistent user experience.
 
   <Frame>
-    <img src="/images/changelog/dashboard_enh.png" alt="Dashboard enhancements including new sidebar, search, and table controls" />
+    <img src="/images/changelog/dashboard_enh.png" alt="Dashboard enhancements including new sidebar, search, and table controls" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Discount Codes for Subscriptions**  
   You can now apply discount codes to subscriptions, specifying the number of billing cycles the discount should apply. This gives you greater flexibility and control over your pricing strategies.
 
   <Frame>
-    <img src="/images/changelog/subs_discount.png" alt="Applying discount codes to subscriptions in the dashboard" />
+    <img src="/images/changelog/subs_discount.png" alt="Applying discount codes to subscriptions in the dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 - **Adaptive Currency Expansion**  

--- a/changelog/v1.66.0.mdx
+++ b/changelog/v1.66.0.mdx
@@ -24,7 +24,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 2. **Minimal Address Support in Checkout**  
 
    <Frame>
-   <img src="/images/changelog/minimal-address.png" alt="Minimal Address Support in Checkout" />
+   <img src="/images/changelog/minimal-address.png" alt="Minimal Address Support in Checkout" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
    Reduce checkout friction with the new minimal address collection mode. Instead of collecting full address details, minimal address mode only collects:

--- a/changelog/v1.67.0.mdx
+++ b/changelog/v1.67.0.mdx
@@ -11,7 +11,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    Checkout now supports combining both one-time payment products and subscription products in a single cart, unlocking powerful new billing use cases.
    
    <Frame>
-   <img src="/images/changelog/mixed-checkout.png" alt="Mixed checkout with one-time and subscription products" />
+   <img src="/images/changelog/mixed-checkout.png" alt="Mixed checkout with one-time and subscription products" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
    
    ### What This Enables
@@ -56,7 +56,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    A new centralized customer portal at [customer.dodopayments.com](https://customer.dodopayments.com) where customers can view and manage all their purchases and subscriptions across different businesses on Dodo Payments.
    
    <Frame>
-   <img src="/images/changelog/unified-customer-portal.png" alt="Unified Customer Portal" />
+   <img src="/images/changelog/unified-customer-portal.png" alt="Unified Customer Portal" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
    
    ### Portal Features

--- a/changelog/v1.7.0.mdx
+++ b/changelog/v1.7.0.mdx
@@ -9,15 +9,15 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 - **Dedicated Subscriptions Page**: Manage customer subscriptions easily with the new dedicated page. Navigate to `Sales > Subscriptions` on the dashboard.
   
-    <Frame><img src="/images/changelog/subscriptions.png" alt="Subscriptions Page"/></Frame>
+    <Frame><img src="/images/changelog/subscriptions.png" alt="Subscriptions Page" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Enhanced Customer Details**: View subscriptions, payments, and refunds for each customer in one place. Go to `Sales > Customers > arrow icon` on the dashboard.
 
-    <Frame><img src="/images/changelog/customer_info.png" alt="Customer Details"/></Frame>
+    <Frame><img src="/images/changelog/customer_info.png" alt="Customer Details" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Detailed Payout Information**: Get more insights on payout amounts, cycles, and dates. Visit `Business > Payouts` on the dashboard.
 
-    <Frame><img src="/images/changelog/payouts_update.png" alt="Payout Information"/></Frame>
+    <Frame><img src="/images/changelog/payouts_update.png" alt="Payout Information" style={{ maxHeight: '500px', width: 'auto' }} /></Frame>
 
 - **Official Ruby SDK**: Integrate Dodo Payments into your Ruby applications effortlessly. Check out the [Ruby SDK](https://github.com/dodopayments/dodopayments-ruby) for more details.
 

--- a/changelog/v1.70.0.mdx
+++ b/changelog/v1.70.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    Embed Dodo Payments checkout directly into your website for a seamless, branded payment experience. Unlike overlay checkout which opens as a modal, inline checkout embeds the payment form directly into your page layout.
 
    <Frame>
-   <img src="/images/inline-checkout/cover.png" alt="Inline Checkout Cover Image" />
+   <img src="/images/inline-checkout/cover.png" alt="Inline Checkout Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
    ### Benefits
@@ -128,7 +128,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
     Manage subscription plans directly from the dashboard with enhanced control. You can now change subscription plans and update the next billing date in a single action, giving you complete flexibility over subscription management.  
 
     <Frame>
-    <img src="/images/changelog/subscription-plan-changes.png" alt="Subscription plan changes in dashboard" />
+    <img src="/images/changelog/subscription-plan-changes.png" alt="Subscription plan changes in dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
 
    ### Dashboard Features
@@ -157,7 +157,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    Generate cleaner, more shareable payment links with our new short link feature. Short links provide shortened checkout URLs with custom slugs, making them easier to share with customers or embed on your website.
 
    <Frame>
-   <img src="/images/changelog/short-links.png" alt="Short links feature for payment URLs" />
+   <img src="/images/changelog/short-links.png" alt="Short links feature for payment URLs" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
    ### Benefits

--- a/changelog/v1.75.0.mdx
+++ b/changelog/v1.75.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    Group related products together for unified checkout experiences, plan selection, and seamless upgrade/downgrade paths within the Customer Portal.
 
    <Frame>
-     <img src="/images/product-collection/checkout-page.png" alt="Product Collection checkout page showing multiple plan options" />
+     <img src="/images/product-collection/checkout-page.png" alt="Product Collection checkout page showing multiple plan options" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
   **Key Benefits**

--- a/changelog/v1.78.0.mdx
+++ b/changelog/v1.78.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
    Take control of how you receive notifications with our revamped Communication Preferences. Configure email, push, and in-app notifications to match your workflow.
 
    <Frame>
-     <img src="/images/communication-preferences/overview.png" alt="Communication Preferences overview showing notification settings" />
+     <img src="/images/communication-preferences/overview.png" alt="Communication Preferences overview showing notification settings" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
    **Key Features**

--- a/changelog/v1.84.0.mdx
+++ b/changelog/v1.84.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 Every product now has its own **dedicated analytics dashboard**. Navigate to **Products > [Select a Product]** to access detailed metrics specific to that product, organized across five tabs:
 
 <Frame>
-<img src="/images/product-analytics/overview.png" alt="Product-Level Analytics" />
+<img src="/images/product-analytics/overview.png" alt="Product-Level Analytics" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Tab | What You Get |
@@ -110,7 +110,7 @@ Learn more: [CLI Documentation](/developer-resources/sdks/cli)
 The Customer Portal has been completely redesigned with a clean, unified interface. The revamped portal features a left sidebar navigation and organized sections, providing customers with a more intuitive self-service experience.
 
 <Frame>
-<img src="/images/customer-portal/new-portal.png" alt="Customer Portal UI Revamp" />
+<img src="/images/customer-portal/new-portal.png" alt="Customer Portal UI Revamp" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **What's New**

--- a/changelog/v1.86.0.mdx
+++ b/changelog/v1.86.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 Dodo Payments now supports **Credit-Based Billing**, a flexible system to issue, manage, and track credit entitlements across subscriptions, one-time products, and usage-based billing. Instead of charging per-use or limiting access through feature flags, you allocate a pool of credits that customers draw from as they consume your service.
 
 <Frame>
-<img src="/images/CBB/Checkout.png" alt="Checkout showing included credits with the product purchase" />
+<img src="/images/CBB/Checkout.png" alt="Checkout showing included credits with the product purchase" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **What You Can Do**
@@ -81,7 +81,7 @@ await fetch('https://api.dodopayments.com/events/ingest', {
 Customers can view and manage their credit balances in the **Customer Portal** under the Credits section, with available balance, transaction history, and usage breakdowns. Credits also appear in checkout, subscription details, and payment transaction pages.
 
 <Frame>
-<img src="/images/CBB/Customer Portal.jpg" alt="Customer Portal credits view with balance and transaction history" />
+<img src="/images/CBB/Customer Portal.jpg" alt="Customer Portal credits view with balance and transaction history" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Webhooks**
@@ -110,7 +110,7 @@ Learn more: [Credit-Based Billing](/features/credit-based-billing) | [Credit Web
 Introducing the new **Design** page, a unified hub for customizing the look and feel of your checkout, storefront, and customer portal from a single place. Choose pre-built themes, configure typography and colors, and apply per-section overrides, all with a live preview before you save.
 
 <Frame>
-<img src="/images/design/general-overview.jpg" alt="Design settings page with live preview of checkout, customer portal, and storefront" />
+<img src="/images/design/general-overview.jpg" alt="Design settings page with live preview of checkout, customer portal, and storefront" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Key Highlights**
@@ -140,7 +140,7 @@ Navigate to **Design** in the main sidebar of your Merchant Dashboard. The page 
 Expand the Advanced Settings on the General tab for granular control over typography (primary/secondary Google Fonts, font size, font weight), color configuration (separate palettes for light and dark mode covering backgrounds, text, buttons, and borders), and border radius for controlling the roundness of UI elements.
 
 <Frame>
-<img src="/images/design/general-color-settings.jpg" alt="Advanced settings expanded showing full color configuration for light and dark modes" />
+<img src="/images/design/general-color-settings.jpg" alt="Advanced settings expanded showing full color configuration for light and dark modes" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Pre-Built Themes**

--- a/changelog/v1.93.0.mdx
+++ b/changelog/v1.93.0.mdx
@@ -14,7 +14,7 @@ The checkout experience has been completely redesigned with **improved loading s
 Additionally, **cancel URL support** is now available — customers can return to your site if they decide not to complete their purchase.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/checkout-redesign.png" alt="Redesigned checkout with improved loading states" />
+<img src="/images/changelog/v1.93.0/checkout-redesign.png" alt="Redesigned checkout with improved loading states" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -26,7 +26,7 @@ Configure the `cancel_url` when creating checkout sessions to provide customers 
 A new **Net Revenue** metric is now available on the analytics page, giving you a clear view of your actual earnings after refunds, disputes, and fees. Track net revenue trends over time and compare across periods to understand your true business performance.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/net-revenue-analytics.png" alt="Net revenue analytics on the dashboard" />
+<img src="/images/changelog/v1.93.0/net-revenue-analytics.png" alt="Net revenue analytics on the dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### 3. **Business-Level Payment Method Disabling**
@@ -34,7 +34,7 @@ A new **Net Revenue** metric is now available on the analytics page, giving you 
 You can now **disable specific payment methods at the business level**. This gives you granular control over which payment options are available to your customers across all checkout sessions, without needing to configure it per product or session.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/payment-method-disabling.png" alt="Business-level payment method disabling in settings" />
+<img src="/images/changelog/v1.93.0/payment-method-disabling.png" alt="Business-level payment method disabling in settings" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -48,7 +48,7 @@ The payouts section now includes a **detailed payout breakdown**, showing exactl
 A new **Payout Breakup API** is also available for programmatic access to payout composition data.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/payout-breakdown.png" alt="Payout breakdown showing transaction-level details" />
+<img src="/images/changelog/v1.93.0/payout-breakdown.png" alt="Payout breakdown showing transaction-level details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### 5. **Visa RDR Configuration**
@@ -56,7 +56,7 @@ A new **Payout Breakup API** is also available for programmatic access to payout
 You can now **configure Visa Rapid Dispute Resolution (RDR)** directly from your business settings. Set your RDR threshold and enable automatic dispute resolution without needing to contact support.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/rdr-configuration.png" alt="Visa RDR configuration in business settings" />
+<img src="/images/changelog/v1.93.0/rdr-configuration.png" alt="Visa RDR configuration in business settings" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -70,7 +70,7 @@ Learn more: [Visa RDR](/features/transactions/disputes#visa-rapid-dispute-resolu
 Checkout sessions and the customer portal now include a **back button**, allowing customers to navigate to previous steps without losing their progress.
 
 <Frame>
-<img src="/images/changelog/v1.93.0/back-button.png" alt="Back button in checkout session" />
+<img src="/images/changelog/v1.93.0/back-button.png" alt="Back button in checkout session" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### 7. **Change Plan on Next Billing Date**

--- a/changelog/v1.94.0.mdx
+++ b/changelog/v1.94.0.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 Automatically detect incomplete or failed checkouts and send targeted email sequences to bring customers back. ACR monitors payments that haven't succeeded after 60 minutes and classifies them as either **payment failed** or **checkout incomplete**, then sends up to 3 configurable recovery emails per sequence.
 
 <Frame>
-<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing abandoned checkout counts, recovery rates, and recovered revenue" />
+<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing abandoned checkout counts, recovery rates, and recovered revenue" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Key capabilities:

--- a/developer-resources/build-an-ai-chat-app-with-usage-based-billing.mdx
+++ b/developer-resources/build-an-ai-chat-app-with-usage-based-billing.mdx
@@ -26,7 +26,7 @@ By the end of this tutorial, you'll have a working chat application that:
 - Includes a beautiful chat interface
 
 <Frame>
-    <img src="/images/cookbooks/ai-chat-app/ai-chat-demo.png" alt="AI Chat Demo"/>
+    <img src="/images/cookbooks/ai-chat-app/ai-chat-demo.png" alt="AI Chat Demo" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## What We're Building
@@ -63,7 +63,7 @@ We'll start by creating a meter in your Dodo Payments dashboard that will track 
 4. Click the **Create Meter** button
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/create-meter.png" alt="Create Meter"/>
+  <img src="/images/cookbooks/ai-chat-app/create-meter.png" alt="Create Meter" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 You should see a form where we'll configure our token tracking.
@@ -102,7 +102,7 @@ We're using "Sum" because we want to add up all tokens consumed across multiple 
 2. Click **Create Meter**
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/meter-configuration.png" alt="Meter Configuration"/>
+  <img src="/images/cookbooks/ai-chat-app/meter-configuration.png" alt="Meter Configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Check>
@@ -196,7 +196,7 @@ Here's where we define our business model:
 **Free Threshold**: Enter → `10000` (customers get 10,000 free tokens per month)
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/product-pricing.png" alt="Product Pricing"/>
+  <img src="/images/cookbooks/ai-chat-app/product-pricing.png" alt="Product Pricing" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -1107,7 +1107,7 @@ Now let's verify the events are being received:
 - Customer ID: Your test customer id
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/meter-event.png" alt="Meter Events"/>
+  <img src="/images/cookbooks/ai-chat-app/meter-event.png" alt="Meter Events" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Check>
@@ -1123,7 +1123,7 @@ Let's send some more messages and check if the token aggregation is working:
 3. Check the "Consumed Units" column - it should show the total tokens used
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/aggregation.png" alt="Meter Customer Tokens"/>
+  <img src="/images/cookbooks/ai-chat-app/aggregation.png" alt="Meter Customer Tokens" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -1142,7 +1142,7 @@ Let's use enough tokens to exceed the free tier:
    - Total Price: ~$0.05
 
 <Frame>
-  <img src="/images/cookbooks/ai-chat-app/free-tier-test.png" alt="Free Tier Test"/>
+  <img src="/images/cookbooks/ai-chat-app/free-tier-test.png" alt="Free Tier Test" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Check>

--- a/developer-resources/inline-checkout.mdx
+++ b/developer-resources/inline-checkout.mdx
@@ -17,7 +17,7 @@ Using inline checkout, you can:
 - Use SDK methods and events to build advanced checkout experiences
 
 <Frame>
-    <img src="/images/inline-checkout/cover.png" alt="Inline Checkout Cover Image"/>
+    <img src="/images/inline-checkout/cover.png" alt="Inline Checkout Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## How It Works
@@ -39,7 +39,7 @@ It's important that customers know who they're buying from, what they're buying,
 To build an inline checkout that's compliant and optimized for conversion, your implementation must include:
 
 <Frame caption="Example inline checkout layout showing required elements">
-    <img src="/images/inline-checkout/example.png" alt="Inline checkout example with required elements labeled"/>
+    <img src="/images/inline-checkout/example.png" alt="Inline checkout example with required elements labeled" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 1. **Recurring information**: If recurring, how often it recurs and the total to pay on renewal. If a trial, how long the trial lasts.
@@ -60,7 +60,7 @@ The checkout flow is determined by your checkout session configuration. Dependin
 <Step title="Customer opens checkout">
 
 You can open inline checkout by passing items or an existing transaction. Use the SDK to show and update on-page information, and SDK methods to update items based on customer interaction.
-    <img src="/images/inline-checkout/1.png" alt="Initial checkout page with items list and payment form"/>
+    <img src="/images/inline-checkout/1.png" alt="Initial checkout page with items list and payment form" style={{ maxHeight: '500px', width: 'auto' }} />
 
 
 </Step>
@@ -79,7 +79,7 @@ After entering their details, customers are presented with available payment met
 
 Display saved payment methods if available to speed up checkout.
 
-<img src="/images/inline-checkout/2.png" alt="Available payment methods and card details form"/>
+<img src="/images/inline-checkout/2.png" alt="Available payment methods and card details form" style={{ maxHeight: '500px', width: 'auto' }} />
 
 </Step>
 
@@ -87,7 +87,7 @@ Display saved payment methods if available to speed up checkout.
 
 Dodo Payments routes every payment to the best acquirer for that sale to get the best possible chance of success. Customers enter a success workflow that you can build.
 
-<img src="/images/inline-checkout/3.png" alt="Success screen with confirmation checkmark"/>
+<img src="/images/inline-checkout/3.png" alt="Success screen with confirmation checkmark" style={{ maxHeight: '500px', width: 'auto' }} />
 
 </Step>
 
@@ -95,7 +95,7 @@ Dodo Payments routes every payment to the best acquirer for that sale to get the
 
 Dodo Payments automatically creates a subscription for the customer, ready for you to provision. The payment method the customer used is held on file for renewals or subscription changes.
 
-<img src="/images/inline-checkout/4.png" alt="Subscription created with webhook notification"/>
+<img src="/images/inline-checkout/4.png" alt="Subscription created with webhook notification" style={{ maxHeight: '500px', width: 'auto' }} />
 
 </Step>
 </Steps>

--- a/developer-resources/overlay-checkout.mdx
+++ b/developer-resources/overlay-checkout.mdx
@@ -10,7 +10,7 @@ keywords: ["Dodo Payments", "developer guide", "overlay checkout", "modal checko
 The Dodo Payments Checkout SDK provides a seamless way to integrate our payment overlay into your web application. Built with TypeScript and modern web standards, it offers a robust solution for handling payments with real-time event handling and customizable themes.
 
 <Frame>
-    <img src="/images/cover-images/overlay-checkout.png" alt="Overlay Checkout Cover Image"/>
+    <img src="/images/cover-images/overlay-checkout.png" alt="Overlay Checkout Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Demo

--- a/developer-resources/seat-based-pricing.mdx
+++ b/developer-resources/seat-based-pricing.mdx
@@ -36,7 +36,7 @@ Before we start, make sure you have:
 Now we need to create an add-on that represents additional seats. This add-on will be attached to our base subscription and allow customers to purchase additional seats.
 
 <Frame>
-  <img src="/images/cookbooks/seat-based/seat-based-addons-creation.png" alt="Creating base subscription product" />
+  <img src="/images/cookbooks/seat-based/seat-based-addons-creation.png" alt="Creating base subscription product" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -84,7 +84,7 @@ Fill in these values for our seat add-on:
 We'll start by creating a base subscription product that includes 5 team members. This will be the foundation of our seat-based pricing model.
 
 <Frame>
-  <img src="/images/cookbooks/seat-based/seat-based-subscription.png" alt="Creating base subscription product" />
+  <img src="/images/cookbooks/seat-based/seat-based-subscription.png" alt="Creating base subscription product" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 
@@ -124,7 +124,7 @@ Now we need to associate our seat add-on with the base subscription so customers
 <Step title="Attach the seat add-on">
 
 <Frame>
-  <img src="/images/cookbooks/seat-based/seat-based-addons.png" alt="Attaching add-on to subscription" />
+  <img src="/images/cookbooks/seat-based/seat-based-addons.png" alt="Attaching add-on to subscription" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 1. Scroll down to the **Add-Ons** section
@@ -390,7 +390,7 @@ Your server should start successfully and show "Server running on http://localho
 <Step title="Test the web interface">
 
 <Frame>
-  <img src="/images/cookbooks/seat-based/seat-based-billing-ui.png" alt="Creating base subscription product" />
+  <img src="/images/cookbooks/seat-based/seat-based-billing-ui.png" alt="Creating base subscription product" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 1. Open your browser and go to `http://localhost:3000`

--- a/developer-resources/sentra.mdx
+++ b/developer-resources/sentra.mdx
@@ -41,7 +41,7 @@ Sentra is available as an extension for VS Code, Cursor, and Windsurf. Choose yo
   <img
     src="/images/sentra/vscode.png"
     alt="VS Code Extensions Marketplace showing Sentra extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -132,7 +132,7 @@ Once installed, you need to configure Sentra with your Dodo Payments API key and
     src="/images/sentra/setup.png"
     alt="Sentra configuration screen with API key input and environment selection"
     width="50%"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -175,7 +175,7 @@ Type what you want to build. For example: "Add usage-based billing with a free t
     src="/images/sentra/welcome.png"
     alt="Sentra interface showing prompt input with example task"
     width="50%"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 

--- a/developer-resources/usage-based-billing-build-ai-image-generator.mdx
+++ b/developer-resources/usage-based-billing-build-ai-image-generator.mdx
@@ -39,7 +39,7 @@ Before we start, make sure you have:
 We'll start by creating a meter in your Dodo Payments dashboard that will track every image our service generates. Think of this as the "counter" that tracks billable events.
 
 <Frame>
-  <img src="/images/usage-based/UBB-2.png" alt="" />
+  <img src="/images/usage-based/UBB-2.png" alt="" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -84,7 +84,7 @@ We're using "Count" because we want to bill per image generated, not by size or 
 <Step title="Add quality filtering">
 
 <Frame>
-  <img src="/images/usage-based/UBB-3.png" alt="" />
+  <img src="/images/usage-based/UBB-3.png" alt="" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 We want to make sure we only count legitimate images (not test runs or failures):
@@ -149,7 +149,7 @@ These will appear on customer invoices, so make them clear and professional.
 <Step title="Connect your meter">
 
 <Frame>
-  <img src="/images/usage-based/UBB-5.png" alt="" />
+  <img src="/images/usage-based/UBB-5.png" alt="" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Before connecting your meter, make sure you have selected **Usage Based Billing** as the price type for your product.
@@ -172,7 +172,7 @@ Your meter is now successfully connected to this product.
 Here's where we define our business model:
 
 <Frame>
-  <img src="/images/usage-based/UBB-4.png" alt="" />
+  <img src="/images/usage-based/UBB-4.png" alt="" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Price Per Unit**: Enter → `0.05` (this is $0.05 per image)
@@ -640,7 +640,7 @@ You should see one event for each image you generated!
 Let's check if the usage counting is working:
 
 <Frame>
-  <img src="/images/usage-based/UBB-1.png" alt="" />
+  <img src="/images/usage-based/UBB-1.png" alt="" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 1. In your meter, go to the **Customers** tab

--- a/developer-resources/usage-based-billing-guide.mdx
+++ b/developer-resources/usage-based-billing-guide.mdx
@@ -415,7 +415,7 @@ Use the time period selector to compare usage across different months and identi
 #### Meter Quantities Chart
 
 <Frame>
-<img src="/images/guides/usage-based-billing/meter-quantities-chart.png" alt="Meter quantities chart showing usage trends over time with purple gradient visualization" />
+<img src="/images/guides/usage-based-billing/meter-quantities-chart.png" alt="Meter quantities chart showing usage trends over time with purple gradient visualization" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The meter quantities chart visualizes usage trends over time with the following features:
@@ -431,7 +431,7 @@ The chart automatically scales based on your usage volume and selected time rang
 ### Events Analytics
 
 <Frame>
-<img src="/images/guides/usage-based-billing/events-table.png" alt="Events table showing event names, IDs, and pagination controls for detailed event analysis" />
+<img src="/images/guides/usage-based-billing/events-table.png" alt="Events table showing event names, IDs, and pagination controls for detailed event analysis" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The Events tab provides granular visibility into individual usage events:

--- a/developer-resources/webhooks.mdx
+++ b/developer-resources/webhooks.mdx
@@ -7,7 +7,7 @@ keywords: ["Dodo Payments", "developer guide", "webhooks"]
 ---
 
 <Frame>
-  <img src="/images/cover-images/Webhooks.webp" alt="Webhook Cover Image"/>
+  <img src="/images/cover-images/Webhooks.webp" alt="Webhook Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Webhooks provide real-time notifications when specific events occur in your Dodo Payments account. Use webhooks to automate workflows, update your database, send notifications, and keep your systems synchronized.
@@ -45,7 +45,7 @@ Our webhook implementation follows the [Standard Webhooks](https://standardwebho
     
 
     <Frame>
-        <img src="/images/webhooks/create-endpoint.png" alt="Add Webhook" />
+        <img src="/images/webhooks/create-endpoint.png" alt="Add Webhook" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
 </Step>
 
@@ -435,7 +435,7 @@ Event-specific payload containing detailed information about the event.
 You can test your webhook integration directly from the Dodo Payments dashboard to ensure your endpoint is working correctly before going live.
 
 <Frame>
-    <img src="/images/webhooks/endpoints.png" alt="Endpoint Details" />
+    <img src="/images/webhooks/endpoints.png" alt="Endpoint Details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Accessing the Testing Interface
@@ -722,7 +722,7 @@ Transformations are particularly useful for:
 The Logs tab provides comprehensive visibility into your webhook delivery status, allowing you to monitor, debug, and manage webhook events effectively.
 
 <Frame>
-    <img src="/images/webhooks/logs.png" alt="Logs" />
+    <img src="/images/webhooks/logs.png" alt="Logs" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Activity Monitoring
@@ -730,7 +730,7 @@ The Logs tab provides comprehensive visibility into your webhook delivery status
 The Activity tab provides real-time insights into your webhook delivery performance with visual analytics.
 
 <Frame>
-    <img src="/images/webhooks/activity.png" alt="Activity" />
+    <img src="/images/webhooks/activity.png" alt="Activity" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Email Alerts
@@ -738,7 +738,7 @@ The Activity tab provides real-time insights into your webhook delivery performa
 Stay informed about your webhook health with automatic email notifications. When webhook deliveries start failing or your endpoint stops responding, you'll receive email alerts so you can quickly address issues and keep your integrations running smoothly.
 
 <Frame>
-  <img src="/images/webhooks/alerting.png" alt="Webhook Alerting Settings showing email notifications configuration" />
+  <img src="/images/webhooks/alerting.png" alt="Webhook Alerting Settings showing email notifications configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Enable Email Alerts

--- a/features/account-summary-payout-wallet.mdx
+++ b/features/account-summary-payout-wallet.mdx
@@ -12,7 +12,7 @@ The **Balances** section provides merchants with a comprehensive overview of the
 ## Key Details
 
 <Frame>
-<img src="/images/balances.png" alt="Balances dashboard showing wallet overview and transaction ledger" />
+<img src="/images/balances.png" alt="Balances dashboard showing wallet overview and transaction ledger" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Wallet Structure

--- a/features/adaptive-currency.mdx
+++ b/features/adaptive-currency.mdx
@@ -45,7 +45,7 @@ Verify a test checkout shows prices in your local currency when supported.
 </Steps>
 
 <Frame>
-  <img src="/images/our-features/adaptive_currency.png" alt="Adaptive Currency"/>
+  <img src="/images/our-features/adaptive_currency.png" alt="Adaptive Currency" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Customer Experience

--- a/features/addons.mdx
+++ b/features/addons.mdx
@@ -31,7 +31,7 @@ Add-ons are supplementary products that customers can purchase alongside their m
 - **Service add-ons**: Professional services, training, or consultation hours
 
 <Frame>
-<img src="/images/cookbooks/seat-based/seat-based-addons.png" alt="Add-ons attached to subscription products in the dashboard" />
+<img src="/images/cookbooks/seat-based/seat-based-addons.png" alt="Add-ons attached to subscription products in the dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Key Benefits
@@ -51,7 +51,7 @@ Add-ons are created as separate products in your Dodo Payments dashboard and the
 - Update add-ons without affecting base subscriptions
 
 <Frame>
-<img src="/images/cookbooks/seat-based/seat-based-addons-creation.png" alt="Creating add-ons in the dashboard interface" />
+<img src="/images/cookbooks/seat-based/seat-based-addons-creation.png" alt="Creating add-ons in the dashboard interface" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Add-on Configuration

--- a/features/analytics-and-reporting.mdx
+++ b/features/analytics-and-reporting.mdx
@@ -6,7 +6,7 @@ icon: "chart-line"
 keywords: ["Dodo Payments", "dashboard analytics", "payment platform", "SaaS billing"]
 ---
 <Frame>
-  <img src="/images/cover-images/Analytics and Reporting.webp" alt="Analytics and Reporting dashboard overview" />
+  <img src="/images/cover-images/Analytics and Reporting.webp" alt="Analytics and Reporting dashboard overview" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Introduction
@@ -39,7 +39,7 @@ The main Analytics dashboard provides comprehensive insights across your entire 
 Track your income and payment activity to understand revenue trends and identify your top-performing markets.
 
 <Frame caption="Total revenue and 30-day trend">
-  <img src="/images/analytics/revenue.png" alt="Total revenue and revenue trend chart" />
+  <img src="/images/analytics/revenue.png" alt="Total revenue and revenue trend chart" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Total Revenue:** Instantly see your all-time revenue and recent trends.
@@ -47,7 +47,7 @@ Track your income and payment activity to understand revenue trends and identify
 - **Revenue Trend:** The 30-day chart helps you spot spikes or dips in income.
 
 <Frame caption="Top 5 revenue-generating countries and growth rate">
-  <img src="/images/analytics/revenue-2.png" alt="Top revenue countries and growth rate chart" />
+  <img src="/images/analytics/revenue-2.png" alt="Top revenue countries and growth rate chart" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Growth Rate:** Track monthly revenue growth to measure business momentum.
@@ -69,7 +69,7 @@ Track your recurring revenue metrics with detailed breakdowns:
 - **Net New MRR Chart**: Net revenue impact combining new, expansion, and churn MRR
 
 <Frame caption="Revenue Breakdown dashboard showing projected ARR, MRR breakdown, and growth rates">
-  <img src="/images/analytics/revenue-breakdown.png" alt="Revenue Breakdown dashboard showing projected ARR, MRR breakdown, and growth rates" />
+  <img src="/images/analytics/revenue-breakdown.png" alt="Revenue Breakdown dashboard showing projected ARR, MRR breakdown, and growth rates" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Retention Analytics
@@ -82,7 +82,7 @@ Monitor customer retention and churn patterns:
 - **User Retention Matrix**: Cohort analysis showing customer retention rates across different time periods
 
 <Frame caption="Retention Analytics showing churn rates and trends">
-  <img src="/images/analytics/retention.png" alt="Retention Analytics dashboard showing customer churn rate, revenue churn rate, and churn rate trends" />
+  <img src="/images/analytics/retention.png" alt="Retention Analytics dashboard showing customer churn rate, revenue churn rate, and churn rate trends" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Customer Analytics
@@ -90,7 +90,7 @@ Monitor customer retention and churn patterns:
 Analyze customer acquisition, retention, and spending patterns to optimize your customer strategy.
 
 <Frame caption="ARPU, active customers, customer split, and top customers">
-  <img src="/images/analytics/customer.png" alt="Customer analytics: ARPU, active customers, customer split, top customers" />
+  <img src="/images/analytics/customer.png" alt="Customer analytics: ARPU, active customers, customer split, top customers" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **ARPU (Average Revenue Per User):** Understand how much each customer contributes on average.
@@ -107,7 +107,7 @@ Monitor ARPU and customer split to refine your retention and acquisition strateg
 Monitor payment and refund success rates to identify and resolve transaction issues quickly.
 
 <Frame caption="Payment/refund success rates, failure reasons, and payment breakdown">
-  <img src="/images/analytics/success-rate.png" alt="Payment and refund success rates, failure reasons, and payment breakdown" />
+  <img src="/images/analytics/success-rate.png" alt="Payment and refund success rates, failure reasons, and payment breakdown" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Payment Success Rate:** Track the percentage of successful payment attempts.
@@ -141,7 +141,7 @@ Use filters to drill down into specific products, time periods, or payment metho
 Beyond business-wide metrics, you can view detailed analytics for **each individual product**. Navigate to **Products > [Select a Product]** to access a dedicated analytics dashboard for that product.
 
 <Frame caption="Product analytics overview showing revenue summary and trend chart">
-  <img src="/images/product-analytics/overview.png" alt="Product analytics overview tab with total revenue, successful payments, and revenue trend chart" />
+  <img src="/images/product-analytics/overview.png" alt="Product analytics overview tab with total revenue, successful payments, and revenue trend chart" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The product analytics dashboard is organized into five tabs:
@@ -186,7 +186,7 @@ Below the chart, a **Transactions** table lists every payment for this product:
 | Refund | Option to initiate a refund |
 
 <Frame caption="Transactions table showing payment history for the product">
-  <img src="/images/product-analytics/overview-transactions.png" alt="Product transactions table with payment IDs, statuses, amounts, and refund actions" />
+  <img src="/images/product-analytics/overview-transactions.png" alt="Product transactions table with payment IDs, statuses, amounts, and refund actions" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Use the **Filter by status** button to narrow the list to successful or failed transactions.
@@ -196,7 +196,7 @@ Use the **Filter by status** button to narrow the list to successful or failed t
 See who is buying this product and how much they're spending.
 
 <Frame caption="Top customers of the month with podium ranking and customer table">
-  <img src="/images/product-analytics/customers.png" alt="Customers tab showing top 3 customers ranked by revenue with a detailed breakdown table" />
+  <img src="/images/product-analytics/customers.png" alt="Customers tab showing top 3 customers ranked by revenue with a detailed breakdown table" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Top Customers of the Month**: A visual podium highlights your **top 3 customers** ranked by total spend, showing revenue amount, name, and email.
@@ -207,7 +207,7 @@ See who is buying this product and how much they're spending.
 Understand how well this product retains its subscribers.
 
 <Frame caption="Customer and revenue churn rates with trend analysis">
-  <img src="/images/product-analytics/retention.png" alt="Retention tab showing customer churn rate, revenue churn rate, and churn rate trend chart" />
+  <img src="/images/product-analytics/retention.png" alt="Retention tab showing customer churn rate, revenue churn rate, and churn rate trend chart" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Customer Churn Rate**: Percentage of subscribers who have cancelled.
@@ -219,7 +219,7 @@ Understand how well this product retains its subscribers.
 A complete list of all subscriptions associated with this product.
 
 <Frame caption="Subscribers table showing all subscriptions with statuses and billing details">
-  <img src="/images/product-analytics/subscribers.png" alt="Subscribers tab with subscription IDs, customer emails, statuses, start dates, and next billing information" />
+  <img src="/images/product-analytics/subscribers.png" alt="Subscribers tab with subscription IDs, customer emails, statuses, start dates, and next billing information" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Column | Description |
@@ -237,7 +237,7 @@ A complete list of all subscriptions associated with this product.
 A detailed breakdown of your product's Monthly Recurring Revenue.
 
 <Frame caption="MRR stacked bar chart showing monthly revenue composition">
-  <img src="/images/product-analytics/mrr.png" alt="MRR tab with stacked bar chart showing new, expansion, and churned MRR by month" />
+  <img src="/images/product-analytics/mrr.png" alt="MRR tab with stacked bar chart showing new, expansion, and churned MRR by month" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The **MRR chart** visualizes your recurring revenue composition month by month as a stacked bar chart.
@@ -245,7 +245,7 @@ The **MRR chart** visualizes your recurring revenue composition month by month a
 Below the chart, four metric cards provide detailed insights:
 
 <Frame caption="Detailed MRR breakdown with New, Expansion, Churned, and Net New MRR">
-  <img src="/images/product-analytics/mrr-breakdown.png" alt="MRR breakdown showing New MRR, Expansion MRR, Churned MRR, and Net New MRR with trend charts" />
+  <img src="/images/product-analytics/mrr-breakdown.png" alt="MRR breakdown showing New MRR, Expansion MRR, Churned MRR, and Net New MRR with trend charts" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Metric | Description |
@@ -275,7 +275,7 @@ Available reports include:
 - **Account Summary Report**: Complete account overview and summary
 
 <Frame caption="Reports dashboard showing available report types">
-  <img src="/images/analytics/reports.png" alt="Reports 2.0 dashboard showing various report types" />
+  <img src="/images/analytics/reports.png" alt="Reports 2.0 dashboard showing various report types" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Payout Reports
@@ -283,7 +283,7 @@ Available reports include:
 Detailed payout reports provide clear visibility into fees and transaction details for each payout. Access these in **Business > Payouts**.
 
 <Frame caption="Payout Report with detailed fee and transaction breakdown">
-  <img src="/images/analytics/payout.png" alt="Payout Report dashboard showing detailed payout information" />
+  <img src="/images/analytics/payout.png" alt="Payout Report dashboard showing detailed payout information" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Downloading Reports

--- a/features/analytics.mdx
+++ b/features/analytics.mdx
@@ -8,7 +8,7 @@ keywords: ["Dodo Payments", "third-party analytics", "payment platform", "SaaS b
 ---
 
 <Frame>
-  <img src="/images/analytics-cover.png" alt="Analytics Integration"/>
+  <img src="/images/analytics-cover.png" alt="Analytics Integration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Track customer journeys from your storefront through checkout to purchase completion. Dodo Payments integrates with Google Analytics 4, Google Tag Manager, and Meta Pixel to provide comprehensive analytics across all your hosted pages.

--- a/features/atlas-demo-website.mdx
+++ b/features/atlas-demo-website.mdx
@@ -6,7 +6,7 @@ keywords: ["Dodo Payments", "atlas demo product", "payment platform", "SaaS bill
 ---
 
 <Frame>
-  <img alt="Atlas Demo Product - AI art generation platform with integrated billing" src="/images/atlas/atlas-demo-product.png" />
+  <img alt="Atlas Demo Product - AI art generation platform with integrated billing" src="/images/atlas/atlas-demo-product.png" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Atlas is a fully functional demo application by Dodo Payments that showcases an AI art generation platform. It demonstrates all three billing models—**usage-based billing**, **one-time payments**, and **subscriptions**—with integrated checkout flows.

--- a/features/checkout.mdx
+++ b/features/checkout.mdx
@@ -7,7 +7,7 @@ keywords: ["Dodo Payments", "checkout features", "payment platform", "SaaS billi
 ---
 
 <Frame>
-  <img src="/images/checkout/cover.png" alt="Checkout page"/>
+  <img src="/images/checkout/cover.png" alt="Checkout page" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -40,7 +40,7 @@ Adaptive Currency allows customers to pay in their preferred local currency, imp
 4. **Display**: Final payable amount is shown transparently before payment
 
 <Frame>
-  <img src="/images/checkout/c1.png" alt="Currency selector on checkout" style={{ width: '70%' }}/>
+  <img src="/images/checkout/c1.png" alt="Currency selector on checkout" style={{ maxHeight: '500px', width: '70%' }}/>
 </Frame>
 
 <Card title="Adaptive Currency" icon="money-bill-transfer" href="/features/adaptive-currency">
@@ -52,7 +52,7 @@ Adaptive Currency allows customers to pay in their preferred local currency, imp
 Dodo Payments supports multiple languages on the checkout page, allowing customers to complete payments in a language they're comfortable with.
 
 <Frame>
-  <img src="/images/checkout/c2.png" alt="Language selector on checkout" style={{ width: '70%' }}/>
+  <img src="/images/checkout/c2.png" alt="Language selector on checkout" style={{ maxHeight: '500px', width: '70%' }}/>
 </Frame>
 
 
@@ -131,7 +131,7 @@ For registered businesses, the checkout allows customers to enter their Business
 - Tax amount updates instantly on checkout
 
 <Frame>
-  <img src="/images/checkout/c3.png" alt="Business Tax ID entry on checkout" style={{ width: '70%' }}/>
+  <img src="/images/checkout/c3.png" alt="Business Tax ID entry on checkout" style={{ maxHeight: '500px', width: '70%' }}/>
 </Frame>
 
 <Info>
@@ -149,7 +149,7 @@ Customers can apply discount or promo codes you've created in the dashboard dire
 3. Updated price and savings are shown clearly
 
 <Frame>
-  <img src="/images/checkout/c4.png" alt="Discount code entry on checkout" style={{ width: '70%' }}/>
+  <img src="/images/checkout/c4.png" alt="Discount code entry on checkout" style={{ maxHeight: '500px', width: '70%' }}/>
 </Frame>
 
 ### API Integration
@@ -328,7 +328,7 @@ After payment, customers are redirected to your `return_url` with query paramete
 Customize the checkout page appearance to match your brand using the `customization.theme_config` parameter when creating a checkout session via the API. Configure colors, fonts, border radius, and button text for both light and dark modes.
 
 <Frame>
-  <img src="/images/checkout/theme-example.png" alt="Custom themed checkout page"/>
+  <img src="/images/checkout/theme-example.png" alt="Custom themed checkout page" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Card title="Design & Theme Customization" icon="palette" href="/features/design">

--- a/features/communication-preferences.mdx
+++ b/features/communication-preferences.mdx
@@ -8,7 +8,7 @@ keywords: ["Dodo Payments", "communication preferences", "payment platform", "Sa
 ---
 
 <Frame>
-    <img src="/images/communication-preferences/overview.png" alt="Communication Preferences Overview"/>
+    <img src="/images/communication-preferences/overview.png" alt="Communication Preferences Overview" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -28,7 +28,7 @@ To configure your communication preferences:
 Dodo Payments supports three notification channels, each designed for different use cases. You can configure each channel independently to match your workflow.
 
 <Frame>
-    <img src="/images/communication-preferences/channel-selector.png" alt="Notification Channel Selector"/>
+    <img src="/images/communication-preferences/channel-selector.png" alt="Notification Channel Selector" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Channel | Description | Best For |
@@ -42,7 +42,7 @@ Dodo Payments supports three notification channels, each designed for different 
 Email is the most flexible notification channel. You can add multiple recipient email addresses, and each recipient can have their own customized notification preferences. This is ideal for routing specific notifications to different team members (e.g., finance team receives payout notifications, support team receives dispute notifications).
 
 <Frame>
-    <img src="/images/communication-preferences/email-notifications.png" alt="Email Notifications Configuration"/>
+    <img src="/images/communication-preferences/email-notifications.png" alt="Email Notifications Configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Key features:**
@@ -56,7 +56,7 @@ Email is the most flexible notification channel. You can add multiple recipient 
 In-app notifications appear in the notification center within your Dodo Payments dashboard. These are perfect for staying informed while actively working in the dashboard without cluttering your email inbox.
 
 <Frame>
-    <img src="/images/communication-preferences/in-app-notifications.png" alt="In-App Notifications"/>
+    <img src="/images/communication-preferences/in-app-notifications.png" alt="In-App Notifications" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 In-app notifications are displayed in real-time and can be accessed by clicking the bell icon in the dashboard header. They provide a quick summary of recent events and link directly to the relevant transaction or record.
@@ -66,7 +66,7 @@ In-app notifications are displayed in real-time and can be accessed by clicking 
 Push notifications deliver instant mobile alerts to your registered devices. This channel is ideal for critical events that require immediate attention, such as payment failures or new disputes.
 
 <Frame>
-    <img src="/images/communication-preferences/push-notifications.png" alt="Push Notifications"/>
+    <img src="/images/communication-preferences/push-notifications.png" alt="Push Notifications" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Push notifications are organized by device, allowing you to:
@@ -89,7 +89,7 @@ The email channel allows you to add multiple recipient addresses, making it easy
 3. Click **Add Email** to confirm
 
 <Frame>
-    <img src="/images/communication-preferences/add-email-modal.png" alt="Add Email Address Modal"/>
+    <img src="/images/communication-preferences/add-email-modal.png" alt="Add Email Address Modal" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 After adding an email, you can immediately configure which notifications that address should receive.
@@ -126,7 +126,7 @@ Stay informed about payment activity for your products.
 Track the movement of funds from your Dodo Payments account to your bank account.
 
 <Frame>
-    <img src="/images/communication-preferences/payout-refund-notifications.png" alt="Payout and Refund Notifications"/>
+    <img src="/images/communication-preferences/payout-refund-notifications.png" alt="Payout and Refund Notifications" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Event | Description |
@@ -159,7 +159,7 @@ Track subscription lifecycle events.
 Disputes require prompt attention to protect your business. These notifications ensure you never miss a dispute deadline.
 
 <Frame>
-    <img src="/images/communication-preferences/subscriptions-disputes.png" alt="Subscription and Dispute Notifications"/>
+    <img src="/images/communication-preferences/subscriptions-disputes.png" alt="Subscription and Dispute Notifications" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Event | Description |
@@ -178,7 +178,7 @@ Disputes have strict response deadlines. We strongly recommend keeping dispute n
 In addition to notifications for your team, you can configure which transactional emails are automatically sent to your customers. These emails are sent from Dodo Payments on your behalf and help keep your customers informed about their purchases.
 
 <Frame>
-    <img src="/images/communication-preferences/customer-emails.png" alt="Customer Email Configuration"/>
+    <img src="/images/communication-preferences/customer-emails.png" alt="Customer Email Configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Email | Description |

--- a/features/credit-based-billing.mdx
+++ b/features/credit-based-billing.mdx
@@ -35,7 +35,7 @@ Credits are ideal for:
 - **SaaS with consumption tiers**: Bundle included usage into credit pools
 
 <Frame caption="Credits appear as entitlements on your products and show in checkout, customer portal, and subscription details.">
-<img src="/images/CBB/Checkout.png" alt="Checkout showing included credits with the product purchase" />
+<img src="/images/CBB/Checkout.png" alt="Checkout showing included credits with the product purchase" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Core Concepts
@@ -98,7 +98,7 @@ Credits can be granted from multiple sources:
 Create credit entitlements in the **Products → Credits** section of your dashboard. Each credit defines the unit, precision, expiry rules, and lifecycle behavior.
 
 <Frame caption="The Credits tab under Products shows all your credit entitlements.">
-<img src="/images/CBB/Desktop - Entitlements  - Credits.jpg" alt="Credits listing page showing created credit entitlements" />
+<img src="/images/CBB/Desktop - Entitlements  - Credits.jpg" alt="Credits listing page showing created credit entitlements" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Steps>
@@ -110,7 +110,7 @@ Go to **Products** in your dashboard and select the **Credits** tab. Click **Cre
 Enter a **Credit Name** - this is your internal identifier for the credit.
 
 <Frame caption="The credit creation form with all configuration sections.">
-<img src="/images/CBB/Desktop - Create Credit.jpg" alt="Credit creation form showing basic info, general settings, and subscription settings" />
+<img src="/images/CBB/Desktop - Create Credit.jpg" alt="Credit creation form showing basic info, general settings, and subscription settings" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -212,7 +212,7 @@ Go to **Products → Create Product** or edit an existing product. Select **Subs
 Expand the **Entitlements** section and click the **Attach** button next to **Credits**.
 
 <Frame caption="The Entitlements section in the product form with Credits, License Key, and Digital Product Delivery options.">
-<img src="/images/CBB/Desktop - Attach Credit - Subscription.jpg" alt="Product entitlements section showing Credits attach button" />
+<img src="/images/CBB/Desktop - Attach Credit - Subscription.jpg" alt="Product entitlements section showing Credits attach button" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -220,7 +220,7 @@ Expand the **Entitlements** section and click the **Attach** button next to **Cr
 An **Add Credits** panel opens. You can select an existing credit from the dropdown or click **Create new credit** to define one on the spot.
 
 <Frame caption="The Add Credits panel lets you select existing credits or create new ones.">
-<img src="/images/CBB/Desktop - Attach Credit - Subscription-2.jpg" alt="Add Credits panel with credit selection dropdown" />
+<img src="/images/CBB/Desktop - Attach Credit - Subscription-2.jpg" alt="Add Credits panel with credit selection dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -252,7 +252,7 @@ Use the default rollover, overage, and expiry settings from the credit entitleme
 </ParamField>
 
 <Frame caption="Credit configuration showing per-cycle amount, trial credits, proration, and custom settings.">
-<img src="/images/CBB/Desktop - Attach Credit - Subscription-4.jpg" alt="Credit configuration form with billing cycle, trial, and proration settings" />
+<img src="/images/CBB/Desktop - Attach Credit - Subscription-4.jpg" alt="Credit configuration form with billing cycle, trial, and proration settings" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -260,7 +260,7 @@ Use the default rollover, overage, and expiry settings from the credit entitleme
 Review the attached credit showing name, amount, and expiration. Click **Add to Subscription** to confirm.
 
 <Frame caption="Review attached credits before adding them to the subscription.">
-<img src="/images/CBB/Desktop - Attach Credit - Subscription-5.jpg" alt="Add Credits panel showing selected credit with details" />
+<img src="/images/CBB/Desktop - Attach Credit - Subscription-5.jpg" alt="Add Credits panel showing selected credit with details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 </Steps>
@@ -274,7 +274,7 @@ For one-time payments, credits are issued **once** at the time of purchase.
 Create a product with **Single Payment** pricing type.
 
 <Frame caption="Single Payment pricing selected for a one-time credit product.">
-<img src="/images/CBB/Desktop - Attach Credit - OTP.jpg" alt="Product pricing section with Single Payment selected" />
+<img src="/images/CBB/Desktop - Attach Credit - OTP.jpg" alt="Product pricing section with Single Payment selected" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -296,7 +296,7 @@ For usage-based products, credits are **linked to meters** and automatically ded
 Select **Usage Based Billing** as the pricing type. Configure the base price and billing frequency.
 
 <Frame caption="Usage Based Billing pricing type with meter configuration.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB.jpg" alt="Usage Based Billing pricing configuration" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB.jpg" alt="Usage Based Billing pricing configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -304,7 +304,7 @@ Select **Usage Based Billing** as the pricing type. Configure the base price and
 Click the **+** button in the **Select meter** section to add a meter. A subscription can have up to **3 meters**.
 
 <Frame caption="The Select Meter panel with meter configuration and credit toggle.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB-3.jpg" alt="Select Meter panel showing free threshold and credit toggle" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB-3.jpg" alt="Select Meter panel showing free threshold and credit toggle" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -324,7 +324,7 @@ The number of usage units required to deduct 1 credit. For example, if set to `1
 </ParamField>
 
 <Frame caption="Credit attached to a meter with per-unit conversion rate.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB-5.jpg" alt="Meter configuration with credit selection and meter units per credit" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB-5.jpg" alt="Meter configuration with credit selection and meter units per credit" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -332,7 +332,7 @@ The number of usage units required to deduct 1 credit. For example, if set to `1
 Set the number of credits issued and optionally customize the credit settings for this product.
 
 <Frame caption="Configure how many credits to issue and whether to use default settings.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB-6.jpg" alt="Credit configuration for UBB product" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB-6.jpg" alt="Credit configuration for UBB product" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -340,7 +340,7 @@ Set the number of credits issued and optionally customize the credit settings fo
 Once configured, the meter shows the attached credit name, unit price, and free threshold.
 
 <Frame caption="Meter with credit attached showing price, threshold, and credit name.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB-1.jpg" alt="Configured meter showing credit attachment details" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB-1.jpg" alt="Configured meter showing credit attachment details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 </Steps>
@@ -407,7 +407,7 @@ Expired credits create a `CreditExpired` ledger entry. If rollover is enabled, t
 When credits are linked to usage meters, the system creates a powerful consumption-based billing model. Customers receive a credit allocation, and usage events automatically deduct from their balance.
 
 <Frame caption="The Usage Billing dashboard shows meter events with units consumed, credits consumed, and customer details.">
-<img src="/images/CBB/Desktop - Usage Billing.jpg" alt="Usage Billing dashboard showing events table with credits consumed" />
+<img src="/images/CBB/Desktop - Usage Billing.jpg" alt="Usage Billing dashboard showing events table with credits consumed" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### How Meter-Based Credit Deduction Works
@@ -438,7 +438,7 @@ The Usage Billing dashboard includes a **Meters** panel listing all defined mete
 When a customer purchases a product with attached credits, the checkout page displays the included credits as part of the product offering.
 
 <Frame caption="Checkout shows included credits with the product, making the value proposition clear.">
-<img src="/images/CBB/Checkout.png" alt="Checkout page showing product with included API call credits" />
+<img src="/images/CBB/Checkout.png" alt="Checkout page showing product with included API call credits" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Credits appear in an **Includes** section below the product description, showing the credit amount and type (e.g., "$1000 API calls").
@@ -448,7 +448,7 @@ Credits appear in an **Includes** section below the product description, showing
 Customers can view and manage their credit balances in the Customer Portal under the **Credits** section.
 
 <Frame caption="The Customer Portal shows available balance and full transaction history.">
-<img src="/images/CBB/Customer Portal.jpg" alt="Customer Portal credits view with balance and transaction history" />
+<img src="/images/CBB/Customer Portal.jpg" alt="Customer Portal credits view with balance and transaction history" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The portal displays:
@@ -471,7 +471,7 @@ Transaction types shown to customers include:
 The subscription detail page shows credit entitlements alongside other plan information.
 
 <Frame caption="Subscription details show credit allocation, remaining balance, and renewal date.">
-<img src="/images/CBB/Desktop - Subscription Details.jpg" alt="Subscription details page showing entitlements and usage history" />
+<img src="/images/CBB/Desktop - Subscription Details.jpg" alt="Subscription details page showing entitlements and usage history" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Key information displayed:
@@ -486,7 +486,7 @@ Key information displayed:
 Payment transaction pages include an **Entitlements** section showing all entitlements delivered with the payment, including credits.
 
 <Frame caption="Transaction details show credits alongside other entitlements like license keys and digital downloads.">
-<img src="/images/CBB/Desktop - Transactions - Payment Summary.jpg" alt="Transaction details page showing credit entitlements" />
+<img src="/images/CBB/Desktop - Transactions - Payment Summary.jpg" alt="Transaction details page showing credit entitlements" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ---
@@ -500,7 +500,7 @@ Payment transaction pages include an **Entitlements** section showing all entitl
 View all your credit entitlements in **Products → Credits**. The table shows credit name, expiry settings, and provides quick actions for editing or archiving.
 
 <Frame caption="Credits listing with total count, creation button, and management actions.">
-<img src="/images/CBB/Desktop - Entitlements  - Credits.jpg" alt="Credits listing page in the Products section" />
+<img src="/images/CBB/Desktop - Entitlements  - Credits.jpg" alt="Credits listing page in the Products section" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 #### Customer Credit Details
@@ -508,7 +508,7 @@ View all your credit entitlements in **Products → Credits**. The table shows c
 View a specific customer's credit balances and transaction history from **Customers → [Customer Name] → Credits**.
 
 <Frame caption="Customer detail page showing credit balance and full transaction ledger.">
-<img src="/images/CBB/Desktop - Customer Details.jpg" alt="Customer details page with Credits tab showing balance and transactions" />
+<img src="/images/CBB/Desktop - Customer Details.jpg" alt="Customer details page with Credits tab showing balance and transactions" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The customer credit view includes:

--- a/features/customer-portal.mdx
+++ b/features/customer-portal.mdx
@@ -24,7 +24,7 @@ Manage recurring plans, upgrades, downgrades, and add‑ons.
 <br/>
 
 <Frame>
-    <img src="/images/customer-portal/new-portal.png" alt="Revamped Customer Portal showing active subscriptions, payment methods, and billing history"/>
+    <img src="/images/customer-portal/new-portal.png" alt="Revamped Customer Portal showing active subscriptions, payment methods, and billing history" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## What Is the Customer Portal?
@@ -67,7 +67,7 @@ https://customer.dodopayments.com/login/{business_id}
 Replace `{business_id}` with your actual business identifier, then share the appropriate link with customers so they can enter their email and receive secure access to the portal.
 
 <Frame>
-    <img src="/images/customer-portal/email-login.png" alt="Email-based login screen"/>
+    <img src="/images/customer-portal/email-login.png" alt="Email-based login screen" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Steps>
@@ -97,7 +97,7 @@ Dynamic links expire after 24 hours. If it expires, generate and send a new link
 </Warning>
 
 <Frame>
-    <img src="/images/customer-portal/magic-link.png" alt="Magic link direct access"/>
+    <img src="/images/customer-portal/magic-link.png" alt="Magic link direct access" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Steps>
@@ -140,7 +140,7 @@ The revamped Customer Portal provides a clean, unified interface with a left sid
 The main portal page displays all active subscriptions, saved payment methods, and billing history in a single scrollable view.
 
 <Frame>
-    <img src="/images/customer-portal/new-portal.png" alt="Customer Portal main page showing active subscriptions and payment methods"/>
+    <img src="/images/customer-portal/new-portal.png" alt="Customer Portal main page showing active subscriptions and payment methods" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Payment Methods & Billing History
@@ -148,7 +148,7 @@ The main portal page displays all active subscriptions, saved payment methods, a
 Scroll down to view saved payment methods and a complete billing history with status indicators and downloadable invoices.
 
 <Frame>
-    <img src="/images/customer-portal/payment-methods-invoices.png" alt="Payment methods and billing history with invoice downloads"/>
+    <img src="/images/customer-portal/payment-methods-invoices.png" alt="Payment methods and billing history with invoice downloads" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Plan Changes (Upgrade/Downgrade)
@@ -199,7 +199,7 @@ When customers click "Manage subscription" on any active subscription, they are 
 - **Cancel Subscription**: A prominent button to cancel the subscription
 
 <Frame>
-    <img src="/images/customer-portal/subscription-details.png" alt="Subscription details page showing plan info, payment method, billing information, and cancel option"/>
+    <img src="/images/customer-portal/subscription-details.png" alt="Subscription details page showing plan info, payment method, billing information, and cancel option" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Cancelling a Subscription
@@ -210,7 +210,7 @@ Customers can cancel their subscription directly from the subscription details p
 - **Cancel now**: The subscription is cancelled immediately.
 
 <Frame>
-    <img src="/images/customer-portal/cance-sub.png" alt="Cancel subscription dialog with options to cancel at next billing date or cancel immediately"/>
+    <img src="/images/customer-portal/cance-sub.png" alt="Cancel subscription dialog with options to cancel at next billing date or cancel immediately" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Updating Payment Methods
@@ -280,7 +280,7 @@ window.location.href = session.link;
 In addition to business-specific customer portals, Dodo Payments offers a **Unified Customer Portal** at [customer.dodopayments.com](https://customer.dodopayments.com) where customers can view and manage all their purchases and subscriptions across different businesses using Dodo Payments.
 
 <Frame>
-    <img src="/images/changelog/unified-customer-portal.png" alt="Unified Customer Portal"/>
+    <img src="/images/changelog/unified-customer-portal.png" alt="Unified Customer Portal" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Unified Portal Features

--- a/features/customer-wallet.mdx
+++ b/features/customer-wallet.mdx
@@ -43,7 +43,7 @@ If you're looking to track virtual usage units (API calls, tokens, compute hours
 </Warning>
 
 <Frame>
-  <img src="/images/customer/customer-wallet.png" alt="Customer Wallets" />
+  <img src="/images/customer/customer-wallet.png" alt="Customer Wallets" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## How It Works

--- a/features/customers.mdx
+++ b/features/customers.mdx
@@ -41,7 +41,7 @@ The Customers Page will display a list of all current and past customers who hav
 </Steps>
 
 <Frame>
-<img src="/images/customer/customers-list.png" alt="Customers list page showing all customers with their details"/>
+<img src="/images/customer/customers-list.png" alt="Customers list page showing all customers with their details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Customer Information
@@ -73,7 +73,7 @@ Use the "Edit Columns" feature to customize your view and show only the informat
 Click on any customer to view their detailed information page, which includes:
 
 <Frame>
-<img src="/images/customer/customer-details.png" alt="Customer details page showing customer information and transaction history"/>
+<img src="/images/customer/customer-details.png" alt="Customer details page showing customer information and transaction history" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### About Section

--- a/features/design.mdx
+++ b/features/design.mdx
@@ -8,7 +8,7 @@ keywords: ["Dodo Payments", "design & theme customization", "payment platform", 
 ---
 
 <Frame>
-  <img src="/images/design/general-overview.jpg" alt="Design settings page with live preview of checkout, customer portal, and storefront"/>
+  <img src="/images/design/general-overview.jpg" alt="Design settings page with live preview of checkout, customer portal, and storefront" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -40,7 +40,7 @@ Navigate to **Settings → Design** in your Merchant Dashboard. The Design page 
 The **General** tab controls your baseline brand identity and global theme.
 
 <Frame>
-  <img src="/images/design/general-advanced-settings.jpg" alt="General tab showing advanced settings with typography, colors, and border configuration"/>
+  <img src="/images/design/general-advanced-settings.jpg" alt="General tab showing advanced settings with typography, colors, and border configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Basic Configuration
@@ -56,7 +56,7 @@ The **General** tab controls your baseline brand identity and global theme.
 Expand **Advanced Settings** to access granular controls:
 
 <Frame>
-  <img src="/images/design/general-color-settings.jpg" alt="Advanced settings expanded showing full color configuration for light and dark modes"/>
+  <img src="/images/design/general-color-settings.jpg" alt="Advanced settings expanded showing full color configuration for light and dark modes" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 #### Typography
@@ -102,13 +102,13 @@ The default Dodo Payments theme. Lime green accents give it an energetic, fresh 
 <Tabs>
 <Tab title="Light Mode">
 <Frame caption="Dodo Pulses in light mode">
-  <img src="/images/design/theme-dodo-pulses-light.png" alt="Dodo Pulses theme in light mode showing checkout, customer portal, and storefront"/>
+  <img src="/images/design/theme-dodo-pulses-light.png" alt="Dodo Pulses theme in light mode showing checkout, customer portal, and storefront" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Dark Mode">
 <Frame caption="Dodo Pulses in dark mode">
-  <img src="/images/design/theme-dodo-pulses-dark.png" alt="Dodo Pulses theme in dark mode showing checkout, customer portal, and storefront"/>
+  <img src="/images/design/theme-dodo-pulses-dark.png" alt="Dodo Pulses theme in dark mode showing checkout, customer portal, and storefront" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>
@@ -120,13 +120,13 @@ A developer-oriented theme with monospaced typography and royal blue accents. Sh
 <Tabs>
 <Tab title="Light Mode">
 <Frame caption="Terminal in light mode">
-  <img src="/images/design/theme-terminal-light.png" alt="Terminal theme in light mode showing checkout with blue accents and monospaced font"/>
+  <img src="/images/design/theme-terminal-light.png" alt="Terminal theme in light mode showing checkout with blue accents and monospaced font" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Dark Mode">
 <Frame caption="Terminal in dark mode">
-  <img src="/images/design/theme-terminal-dark.png" alt="Terminal theme in dark mode showing checkout with blue accents and monospaced font"/>
+  <img src="/images/design/theme-terminal-dark.png" alt="Terminal theme in dark mode showing checkout with blue accents and monospaced font" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>
@@ -138,13 +138,13 @@ Warm amber and gold accents with rounded, modern styling. Bold and high-contrast
 <Tabs>
 <Tab title="Light Mode">
 <Frame caption="Bumblebee in light mode">
-  <img src="/images/design/theme-bumblebee-light.png" alt="Bumblebee theme in light mode showing checkout with amber accents"/>
+  <img src="/images/design/theme-bumblebee-light.png" alt="Bumblebee theme in light mode showing checkout with amber accents" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Dark Mode">
 <Frame caption="Bumblebee in dark mode">
-  <img src="/images/design/theme-bumblebee-dark.png" alt="Bumblebee theme in dark mode showing checkout with gold accents"/>
+  <img src="/images/design/theme-bumblebee-dark.png" alt="Bumblebee theme in dark mode showing checkout with gold accents" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>
@@ -156,13 +156,13 @@ Playful pink and magenta accents with fully rounded corners. A modern, approacha
 <Tabs>
 <Tab title="Light Mode">
 <Frame caption="Bubblegum in light mode">
-  <img src="/images/design/theme-bubblegum-light.png" alt="Bubblegum theme in light mode showing checkout, customer portal, and storefront with pink accents"/>
+  <img src="/images/design/theme-bubblegum-light.png" alt="Bubblegum theme in light mode showing checkout, customer portal, and storefront with pink accents" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Dark Mode">
 <Frame caption="Bubblegum in dark mode">
-  <img src="/images/design/theme-bubblegum-dark.png" alt="Bubblegum theme in dark mode showing checkout, customer portal, and storefront with pink accents"/>
+  <img src="/images/design/theme-bubblegum-dark.png" alt="Bubblegum theme in dark mode showing checkout, customer portal, and storefront with pink accents" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>
@@ -178,7 +178,7 @@ Each section tab (Checkout, Storefront, Customer Portal) includes an **Override 
 ### Checkout Tab
 
 <Frame>
-  <img src="/images/design/checkout-tab.jpg" alt="Checkout tab showing full checkout preview with product details and payment form"/>
+  <img src="/images/design/checkout-tab.jpg" alt="Checkout tab showing full checkout preview with product details and payment form" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Override typography, colors, and border settings specifically for the checkout experience. The live preview shows:
@@ -190,7 +190,7 @@ Override typography, colors, and border settings specifically for the checkout e
 ### Storefront Tab
 
 <Frame>
-  <img src="/images/design/storefront-tab.jpg" alt="Storefront tab showing store URL, branding controls, and storefront preview"/>
+  <img src="/images/design/storefront-tab.jpg" alt="Storefront tab showing store URL, branding controls, and storefront preview" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Configure storefront-specific settings:
@@ -207,7 +207,7 @@ Configure storefront-specific settings:
 ### Customer Portal Tab
 
 <Frame>
-  <img src="/images/design/customer-portal-tab.jpg" alt="Customer portal tab showing subscription management, billing history, and payment methods preview"/>
+  <img src="/images/design/customer-portal-tab.jpg" alt="Customer portal tab showing subscription management, billing history, and payment methods preview" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Override the theme for the customer portal, which includes:

--- a/features/digital-product-delivery.mdx
+++ b/features/digital-product-delivery.mdx
@@ -45,7 +45,7 @@ Choose one of the following options:
 - **External Download Link**: Paste a secure link hosted externally (e.g., Dropbox, Google Drive)
 
 <Frame>
-<img src="/images/digital-product-delivery/1.png" alt="Digital product delivery configuration interface showing file upload and external link options" />
+<img src="/images/digital-product-delivery/1.png" alt="Digital product delivery configuration interface showing file upload and external link options" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Step>
 
@@ -65,7 +65,7 @@ Uploaded files are served via static URLs — anyone with the link can access th
 After a successful transaction, customers receive a purchase confirmation email containing download links for their digital products.
 
 <Frame>
-<img src="/images/digital-product-delivery/2.png" alt="Purchase confirmation email showing download links for digital products" />
+<img src="/images/digital-product-delivery/2.png" alt="Purchase confirmation email showing download links for digital products" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Customer Portal Access
@@ -77,7 +77,7 @@ Customers can access their digital products through the Customer Portal:
 - Persistent access to purchased digital content
 
 <Frame>
-<img src="/images/digital-product-delivery/3.png" alt="Customer portal interface showing available digital products for download" />
+<img src="/images/digital-product-delivery/3.png" alt="Customer portal interface showing available digital products for download" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Check>

--- a/features/discount-codes.mdx
+++ b/features/discount-codes.mdx
@@ -7,7 +7,7 @@ keywords: ["Dodo Payments", "discounts", "payment platform", "SaaS billing"]
 ---
 
 <Frame>
-    <img src="/images/discount-codes/discount-code-cover.png" alt="Discount codes overview cover"/>
+    <img src="/images/discount-codes/discount-code-cover.png" alt="Discount codes overview cover" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Discount codes let you run targeted promotions and incentives. Create percentage or fixed-amount discounts, set limits and expirations, restrict to products, and apply them seamlessly in checkout.

--- a/features/feature-request.mdx
+++ b/features/feature-request.mdx
@@ -15,7 +15,7 @@ View all feature requests, vote on ideas, and track our product roadmap on Featu
 
 If you have an idea for a feature that would enhance your experience with Dodo Payments, you can submit a feature request directly on Featurebase.
 
-<img src="/images/feature-request/Feature.png" alt="Feature Request"/>
+<img src="/images/feature-request/Feature.png" alt="Feature Request" style={{ maxHeight: '500px', width: 'auto' }} />
 
 - **How to Request a Feature**:
     1. Visit our [Featurebase portal](https://dodopayments.featurebase.app/).

--- a/features/invoice-generation.mdx
+++ b/features/invoice-generation.mdx
@@ -6,7 +6,7 @@ keywords: ["Dodo Payments", "invoice management", "payment platform", "SaaS bill
 ---
 
 <Frame>
-<img src="/images/cover-images/Invoice Generation.webp" alt="Invoice Generation Cover Image"/>
+<img src="/images/cover-images/Invoice Generation.webp" alt="Invoice Generation Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Overview
@@ -124,7 +124,7 @@ Use the search and filter options to quickly locate invoices for accounting or c
 Here's what your branded invoices will look like:
 
 <Frame caption="Example of a generated invoice with custom branding">
-<img src="/images/invoice-generation/image.png" alt="Invoice template showing business branding, transaction details, and professional layout"/>
+<img src="/images/invoice-generation/image.png" alt="Invoice template showing business branding, transaction details, and professional layout" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Related Features

--- a/features/license-keys.mdx
+++ b/features/license-keys.mdx
@@ -58,7 +58,7 @@ License keys are unique tokens that authorize access to your product. They're id
 </Steps>
 
 <Frame>
-    <img src="/images/license-keys/1.webp" alt="Creating a license key in Dodo Payments dashboard"/>
+    <img src="/images/license-keys/1.webp" alt="Creating a license key in Dodo Payments dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Manage & Monitor
@@ -74,7 +74,7 @@ View detailed information for each license key:
 - **Expiry and Limits**: Key expiry date, remaining activation count, and current activation instances
 
 <Frame>
-    <img src="/images/license-keys/3.webp" alt="License key details"/>
+    <img src="/images/license-keys/3.webp" alt="License key details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Available Actions
@@ -86,7 +86,7 @@ You can perform the following actions on license keys:
 - **View Activation Instances**: See all associated activation instances for a particular license key
 
 <Frame>
-    <img src="/images/license-keys/2.webp" alt="License key actions"/>
+    <img src="/images/license-keys/2.webp" alt="License key actions" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Benefits

--- a/features/one-time-payment-products.mdx
+++ b/features/one-time-payment-products.mdx
@@ -49,7 +49,7 @@ One‑time payments are fixed, up‑front purchases - ideal for:
 Create products in your Dodo Payments dashboard, then sell them via hosted checkout, payment links, or your API.
 
 <Frame>
-  <img src="/images/products.png" alt="One-Time Payment Products" />
+  <img src="/images/products.png" alt="One-Time Payment Products" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Product configuration

--- a/features/payouts/payout-structure.mdx
+++ b/features/payouts/payout-structure.mdx
@@ -10,7 +10,7 @@ keywords: ["Dodo Payments", "payouts", "merchant payouts", "revenue transfer", "
 The **Payouts Section** consolidates all eligible earnings that can be disbursed in the next payout cycle. It provides transparency on the net available balance after accounting for all fees, refunds, and taxes.
 
 <Frame>
-  <img src="/images/payouts/payout-section.png" alt="Payouts section showing balance eligible for payout" />
+  <img src="/images/payouts/payout-section.png" alt="Payouts section showing balance eligible for payout" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Key Features
@@ -96,7 +96,7 @@ You can customize the balance that must build up in your USD wallet before Dodo 
 ### How to Edit Your Threshold
 
 <Frame>
-  <img src="/images/payouts/payout-threshold-edit.png" alt="Edit payout threshold in dashboard" />
+  <img src="/images/payouts/payout-threshold-edit.png" alt="Edit payout threshold in dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Steps>
@@ -154,7 +154,7 @@ A reverse invoice is generated to indicate the amount paid by Dodo Payments to t
 ### Invoice Structure
 
 <Frame>
-  <img src="/images/payouts/payout-process/Invoice - Payout.png" alt="Payout invoice structure example" width="60%" />
+  <img src="/images/payouts/payout-process/Invoice - Payout.png" alt="Payout invoice structure example" width="60%" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Important Disclaimer for Indian Businesses

--- a/features/product-collections.mdx
+++ b/features/product-collections.mdx
@@ -14,7 +14,7 @@ Product Collections let you group related products (e.g., Starter, Pro, Enterpri
   <img 
     src="/images/product-collection/checkout-page.png" 
     alt="Screenshot of the Product Collection checkout page showing multiple products displayed" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Key Highlights
@@ -37,7 +37,7 @@ Define the collection with a name and optional description. Upload an image to v
   <img 
     src="/images/product-collection/collection-form.png" 
     alt="Screenshot of the Product Collection creation form in the dashboard showing fields for name, description, and image upload" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Collection fields:**
@@ -54,7 +54,7 @@ Add existing products to your collection. Products can be organized into groups 
   <img 
     src="/images/product-collection/collection-form-products.png" 
     alt="Screenshot of the Product Collection products page showing a list of products and the ability to add them to the collection" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Product organization:**
@@ -107,7 +107,7 @@ When using a collection checkout:
   <img 
     src="/images/product-collection/checkout-page.png" 
     alt="Screenshot of the Product Collection checkout page showing multiple products displayed" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -154,7 +154,7 @@ Customers can upgrade or downgrade between products within the same collection d
   <img 
     src="/images/product-collection/portal.png" 
     alt="Screenshot of the Product Collection customer portal plan change interface showing the plan management actions" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Upgrade/Downgrade Rules
@@ -167,7 +167,7 @@ Customers can upgrade or downgrade between products within the same collection d
   <img 
     src="/images/product-collection/portal-change-plan.png" 
     alt="Screenshot of the Product Collection customer portal plan change interface showing the plan management actions" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>
@@ -182,7 +182,7 @@ Configure how subscriptions and plan changes work across your business from **Se
   <img 
     src="/images/product-collection/business-settings.png" 
     alt="Screenshot of the subscription settings page showing Allow Multiple Subscriptions and Allow Subscription Updates toggles" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Available Settings
@@ -220,7 +220,7 @@ Creating, updating, and deleting collections is only available via the dashboard
   <img 
     src="/images/product-collection/collection-dashboard.png" 
     alt="Screenshot of the Product Collection dashboard showing the collection management operations" 
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Best Practices

--- a/features/products.mdx
+++ b/features/products.mdx
@@ -36,7 +36,7 @@ Keep the first sentence customer‑facing and outcome‑oriented; it appears pro
 </Tip>
 
 <Frame>
-  <img src="/images/products.png" alt="Products"/>
+  <img src="/images/products.png" alt="Products" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 </Step>
@@ -79,7 +79,7 @@ Add or remove benefits as your offer evolves. Existing subscribers gain or lose 
 Instead of variants under one product, create separate products for each pricing option (for example, Monthly and Yearly). Then group them into a **Product Collection** to present all options in a single checkout and enable plan switching in the Customer Portal.
 
 <Frame>
-  <img src="/images/product-collection/checkout-page.png" alt="Product Collections"/>
+  <img src="/images/product-collection/checkout-page.png" alt="Product Collections" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Why this approach?

--- a/features/purchasing-power-parity.mdx
+++ b/features/purchasing-power-parity.mdx
@@ -44,7 +44,7 @@ Both platforms integrate directly with Dodo Payments to create and manage discou
 When ParityDeals is integrated into your website, eligible visitors will see a banner that includes a location-based discount code they can use at checkout. These discount codes are automatically created and managed by ParityDeals and will appear in your **Dodo Payments Dashboard** under **Sales → Discounts**.
 
 <Frame>
-  <img src="/images/ppp/1.png" alt="ParityDeals discount banner example" />
+  <img src="/images/ppp/1.png" alt="ParityDeals discount banner example" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Setup
@@ -58,7 +58,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     After signing in, locate the option to create deals. From the dropdown menu, select **"Create Deals via Dodo Payments"**.
 
     <Frame>
-      <img src="/images/ppp/2.png" alt="Creating deals via Dodo Payments" />
+      <img src="/images/ppp/2.png" alt="Creating deals via Dodo Payments" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -70,7 +70,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     </Tip>
 
     <Frame>
-      <img src="/images/ppp/3.png" alt="Creating a new API key in Dodo Payments" />
+      <img src="/images/ppp/3.png" alt="Creating a new API key in Dodo Payments" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -78,7 +78,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     Copy the API key you created and paste it into the ParityDeals interface to establish the connection with your Dodo Payments account.
 
     <Frame>
-      <img src="/images/ppp/4.png" alt="Connecting API key to ParityDeals" />
+      <img src="/images/ppp/4.png" alt="Connecting API key to ParityDeals" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -86,7 +86,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     Once connected, ParityDeals will fetch your Dodo Payments product catalog. Select the products you want to associate with your deals.
 
     <Frame>
-      <img src="/images/ppp/5.png" alt="Selecting products for ParityDeals" />
+      <img src="/images/ppp/5.png" alt="Selecting products for ParityDeals" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -97,7 +97,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     - Time-based flash deals
 
     <Frame>
-      <img src="/images/ppp/6.png" alt="Configuring deal settings" />
+      <img src="/images/ppp/6.png" alt="Configuring deal settings" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -105,7 +105,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     Select the countries you want to offer localized discounts to and define the discount percentage for each. ParityDeals provides recommended defaults that you can adjust as needed.
 
     <Frame>
-      <img src="/images/ppp/7.png" alt="Setting country-based discount rules" />
+      <img src="/images/ppp/7.png" alt="Setting country-based discount rules" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -113,7 +113,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     Design your discount banner by customizing the text, selecting colors and layout, and choosing the banner position (top or bottom of page). This banner will be displayed to eligible visitors based on your configured rules.
 
     <Frame>
-      <img src="/images/ppp/8.png" alt="Customizing the discount banner" />
+      <img src="/images/ppp/8.png" alt="Customizing the discount banner" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 
@@ -121,7 +121,7 @@ When ParityDeals is integrated into your website, eligible visitors will see a b
     After saving your deal, ParityDeals will generate a script. Add this script to your website code (typically in the `<head>` section). This script automatically detects visitor locations and displays the appropriate discount banner.
 
     <Frame>
-      <img src="/images/ppp/9.png" alt="ParityDeals integration script" />
+      <img src="/images/ppp/9.png" alt="ParityDeals integration script" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
   </Step>
 </Steps>
@@ -135,7 +135,7 @@ With ParityDeals, you can also offer [automatic time-based discounts](https://ww
 [Evendeals](https://www.evendeals.com/integrations/dodo-payments) is another platform that integrates with Dodo Payments to offer location-based purchasing power parity pricing. It supports both one-time and subscription products.
 
 <Frame>
-  <img src="/images/ppp/evendeals-hero.png" alt="Evendeals Dodo Payments integration overview" />
+  <img src="/images/ppp/evendeals-hero.png" alt="Evendeals Dodo Payments integration overview" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Key Features
@@ -150,7 +150,7 @@ Discount codes created by Evendeals will automatically appear in your Dodo Payme
 </Info>
 
 <Frame>
-  <img src="/images/ppp/evendeals-features.png" alt="Evendeals key features for Dodo Payments integration" />
+  <img src="/images/ppp/evendeals-features.png" alt="Evendeals key features for Dodo Payments integration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Setup
@@ -174,7 +174,7 @@ Discount codes created by Evendeals will automatically appear in your Dodo Payme
 </Steps>
 
 <Frame>
-  <img src="/images/ppp/evendeals-setup.png" alt="Evendeals setup guide for Dodo Payments" />
+  <img src="/images/ppp/evendeals-setup.png" alt="Evendeals setup guide for Dodo Payments" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Both ParityDeals and Evendeals work seamlessly with Dodo Payments to help you optimize your global pricing strategy. For more details, visit the [ParityDeals Documentation](https://www.paritydeals.com/docs/) or the [Evendeals Dodo Payments integration page](https://www.evendeals.com/integrations/dodo-payments).

--- a/features/recovery/abandoned-cart-recovery.mdx
+++ b/features/recovery/abandoned-cart-recovery.mdx
@@ -99,13 +99,13 @@ ACR sends different emails depending on the abandonment reason. Below are exampl
 <Tabs>
 <Tab title="Payment Failed">
 <Frame caption="Recovery email sent when a payment attempt fails">
-<img src="/images/recovery/acr-failed-email.png" alt="Recovery email for a failed payment showing store name, message about payment failure, order summary with product details, discount, and a Resume Checkout button" />
+<img src="/images/recovery/acr-failed-email.png" alt="Recovery email for a failed payment showing store name, message about payment failure, order summary with product details, discount, and a Resume Checkout button" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Checkout Incomplete">
 <Frame caption="Recovery email sent when a customer leaves without attempting payment">
-<img src="/images/recovery/acr-abandoned-email.png" alt="Recovery email for an incomplete checkout showing store name, message about saved cart, order summary with product details, discount, and a Resume Checkout button" />
+<img src="/images/recovery/acr-abandoned-email.png" alt="Recovery email for an incomplete checkout showing store name, message about saved cart, order summary with product details, discount, and a Resume Checkout button" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>

--- a/features/recovery/abandoned-cart-recovery.mdx
+++ b/features/recovery/abandoned-cart-recovery.mdx
@@ -56,7 +56,7 @@ Each abandoned checkout progresses through these states:
 Enable and configure ACR from **Settings** in your dashboard.
 
 <Frame caption="Abandoned Cart Recovery settings in the dashboard">
-<img src="/images/recovery/acr-settings.png" alt="ACR settings page showing enable toggle, discount configuration, and email sequence editor" />
+<img src="/images/recovery/acr-settings.png" alt="ACR settings page showing enable toggle, discount configuration, and email sequence editor" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Global Settings
@@ -73,7 +73,7 @@ Enable and configure ACR from **Settings** in your dashboard.
 ACR supports two email sequences — **Payment Failed** and **Checkout Incomplete** — each with up to 3 configurable emails.
 
 <Frame caption="ACR email sequence configuration">
-<img src="/images/recovery/acr-email-config.png" alt="Email sequence editor showing subject, body, timing, and enable toggle for each email in the sequence" />
+<img src="/images/recovery/acr-email-config.png" alt="Email sequence editor showing subject, body, timing, and enable toggle for each email in the sequence" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Setting | Description |
@@ -134,7 +134,7 @@ behind, along with a discount code if one has been configured.
 Track the performance of ACR from the **Analytics** section of your dashboard.
 
 <Frame caption="Recovery analytics dashboard showing ACR and dunning metrics">
-<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing abandoned checkout counts, recovery rates, recovered revenue, average time to recover, and breakdowns by product and email" />
+<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing abandoned checkout counts, recovery rates, recovered revenue, average time to recover, and breakdowns by product and email" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Metric | Description |

--- a/features/recovery/subscription-dunning.mdx
+++ b/features/recovery/subscription-dunning.mdx
@@ -91,13 +91,13 @@ Dunning sends different emails depending on the subscription state. Below are ex
 <Tabs>
 <Tab title="On Hold">
 <Frame caption="Dunning email sent when a renewal payment fails and the subscription is on hold">
-<img src="/images/recovery/dunning-on-hold-email.png" alt="Dunning email for an on-hold subscription showing store name, message about failed payment, subscription details with plan and amount, and an Update Payment Method button" />
+<img src="/images/recovery/dunning-on-hold-email.png" alt="Dunning email for an on-hold subscription showing store name, message about failed payment, subscription details with plan and amount, and an Update Payment Method button" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 
 <Tab title="Cancelled">
 <Frame caption="Dunning email sent when a customer cancels their subscription">
-<img src="/images/recovery/dunning-cancelled-email.png" alt="Dunning email for a cancelled subscription showing store name, message about cancellation, subscription details with plan and amount, and a Re-purchase Subscription button" />
+<img src="/images/recovery/dunning-cancelled-email.png" alt="Dunning email for a cancelled subscription showing store name, message about cancellation, subscription details with plan and amount, and a Re-purchase Subscription button" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Tab>
 </Tabs>

--- a/features/recovery/subscription-dunning.mdx
+++ b/features/recovery/subscription-dunning.mdx
@@ -54,7 +54,7 @@ When a dunning attempt is marked as `exhausted`, the subscription state is not m
 Enable and configure Dunning from **Settings** in your dashboard.
 
 <Frame caption="Dunning settings in the dashboard showing enable toggle, on-hold sequence, and cancelled sequence">
-<img src="/images/recovery/dunning-settings.png" alt="Dunning settings page with enable toggle, four on-hold emails at 1, 3, 5, and 7 day intervals, and four cancelled emails at the same intervals" />
+<img src="/images/recovery/dunning-settings.png" alt="Dunning settings page with enable toggle, four on-hold emails at 1, 3, 5, and 7 day intervals, and four cancelled emails at the same intervals" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Email Sequences
@@ -107,7 +107,7 @@ Dunning sends different emails depending on the subscription state. Below are ex
 When a customer clicks the link in a dunning email, they are taken to the customer portal where they can see their subscription status and update their payment method.
 
 <Frame caption="Customer portal showing an on-hold subscription with option to update payment method">
-<img src="/images/recovery/customer-recovery-page.png" alt="Customer portal showing an on-hold subscription for Pro Plan at $95.00/year with an Update payment method button and a warning banner about the failed payment" />
+<img src="/images/recovery/customer-recovery-page.png" alt="Customer portal showing an on-hold subscription for Pro Plan at $95.00/year with an Update payment method button and a warning banner about the failed payment" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 After the customer updates their payment method, a charge is automatically created for any outstanding dues. If the payment succeeds, the subscription is reactivated immediately.
@@ -119,7 +119,7 @@ For a cancelled subscription, customer is taken to a checkout page that already 
 Track the performance of Dunning from the **Recovery** tab in the **Analytics** section of your dashboard.
 
 <Frame caption="Recovery analytics dashboard showing ACR and dunning metrics">
-<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing dunning entry counts, success rates, recovered revenue, and per-email performance breakdown" />
+<img src="/images/recovery/recovery-analytics.png" alt="Recovery analytics dashboard showing dunning entry counts, success rates, recovered revenue, and per-email performance breakdown" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 | Metric | Description |

--- a/features/storefront.mdx
+++ b/features/storefront.mdx
@@ -5,7 +5,7 @@ icon: "store"
 keywords: ["Dodo Payments", "storefront", "payment platform", "SaaS billing"]
 ---
 <Frame>
-    <img src="/images/cover-images/Storefront.png" alt="Storefront Cover Image"/>
+    <img src="/images/cover-images/Storefront.png" alt="Storefront Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Key Highlights of the Feature
@@ -28,7 +28,7 @@ keywords: ["Dodo Payments", "storefront", "payment platform", "SaaS billing"]
 
 Below is the step-by-step process for merchants to set up and manage their storefront:
 
-<img src="/images/store-front/sf-1.png"/>
+<img src="/images/store-front/sf-1.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 ### Accessing Your Storefront Settings
 
@@ -46,7 +46,7 @@ Below is the step-by-step process for merchants to set up and manage their store
 
 ### Saving & Viewing Your Store
 
-<img src="/images/store-front/sf-2.png"/>
+<img src="/images/store-front/sf-2.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 1. **Click Publish**: Click Publish to confirm your storefront setup and product publishing decisions.
 2. **Preview Store**: You can preview your storefront at the generated URL.
@@ -54,7 +54,7 @@ Below is the step-by-step process for merchants to set up and manage their store
 
 ### Test Mode
 
-<img src="/images/store-front/sf-3.png"/>
+<img src="/images/store-front/sf-3.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 Test Mode and Live Mode have separate storefronts. You can see the test mode indicator on the top of your website and store front generated through test mode as well. 
 
@@ -64,7 +64,7 @@ Test Mode is for you try out the user flow and purchase experience on the store.
 
 ## Customer Experience
 
-<img src="/images/store-front/sf-4.png"/>
+<img src="/images/store-front/sf-4.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 ### Landing on the Storefront
 
@@ -77,7 +77,7 @@ Test Mode is for you try out the user flow and purchase experience on the store.
 - **Quantity Selection**: Customers can pick how many items they want to buy.
 - **Subscription Frequency & Trial**: Subscription products explicitly state billing frequency (e.g., monthly) and if a trial is available (e.g., 7-day free trial).
 
-<img src="/images/store-front/sf-5.png"/>
+<img src="/images/store-front/sf-5.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 ### Buying Process
 

--- a/features/team.mdx
+++ b/features/team.mdx
@@ -5,24 +5,24 @@ icon: "user-gear"
 keywords: ["Dodo Payments", "team members", "payment platform", "SaaS billing"]
 ---
 <Frame>
-    <img src="/images/cover-images/Team.png" alt="Team Cover Image"/>
+    <img src="/images/cover-images/Team.png" alt="Team Cover Image" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## How to add a teammate?
 
-<img src="/images/team/team-1.png"/>
+<img src="/images/team/team-1.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 1. Go to Settings → Team.
 2. Click on +**invite** button on the top right corner.
 
-<img src="/images/team/team-2.png"/>
+<img src="/images/team/team-2.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 3. Provide the teammates email and assign a role to them.
 4. Click on **Send Invite**.
 
 ## How can a teammate access the dashboard?
 
-<img src="/images/team/team-3.png"/>
+<img src="/images/team/team-3.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 1. The teammate receives an invitation link via email and clicks on it.
 2. If they do not have a Dodo Payments account, they are directed to the signup page where they need to provide the required details. If they already have a Dodo Payments account they can access the business through the business toggle on the bottom left. 
@@ -30,7 +30,7 @@ keywords: ["Dodo Payments", "team members", "payment platform", "SaaS billing"]
 
 ## Roles and Permissions
 
-<img src="/images/team/team-4.png"/>
+<img src="/images/team/team-4.png" style={{ maxHeight: '500px', width: 'auto' }} />
 
 The Dodo Dashboard has three types of user roles, each with different levels of access. The role icon of the user can be seen in the bottom left of the dashboard.
 

--- a/features/transactions/disputes.mdx
+++ b/features/transactions/disputes.mdx
@@ -40,7 +40,7 @@ When a dispute is raised against your transaction, follow these steps to respond
    - You can either accept or counter the dispute
    
    <Frame>
-       <img src="/images/disputes/1.png" alt="Dispute Creation" />
+       <img src="/images/disputes/1.png" alt="Dispute Creation" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
 4. **If Accepting**
@@ -52,11 +52,11 @@ When a dispute is raised against your transaction, follow these steps to respond
    - Follow the best practices below
    
    <Frame>
-       <img src="/images/disputes/2.png" alt="Dispute Creation" />
+       <img src="/images/disputes/2.png" alt="Dispute Creation" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
    
    <Frame>
-       <img src="/images/disputes/3.png" alt="Dispute Creation" />
+       <img src="/images/disputes/3.png" alt="Dispute Creation" style={{ maxHeight: '500px', width: 'auto' }} />
    </Frame>
 
 <Info>
@@ -243,7 +243,7 @@ For example, with a \$100 threshold: a \$75 dispute is auto-resolved (refunded),
 Visa RDR is **enabled by default** on all Dodo Payments accounts with a **\$100 USD threshold**. This means any Visa dispute at or below \$100 is automatically resolved with a refund -- no action needed from you.
 
 <Frame caption="Visa RDR configuration in the Dodo Payments dashboard">
-    <img src="/images/disputes/rdr.png" alt="Visa RDR settings showing the enabled toggle and threshold configuration" />
+    <img src="/images/disputes/rdr.png" alt="Visa RDR settings showing the enabled toggle and threshold configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 #### Customizing Your Threshold

--- a/features/transactions/payments.mdx
+++ b/features/transactions/payments.mdx
@@ -40,7 +40,7 @@ Upon clicking a payment in the listing, merchants are directed to the **Payment 
 ### Successful payment
 
 <Frame caption="Example of a successfully captured card payment">
-<img src="/images/transactions/payments/successful-payment.png" alt="Payment details page showing a successful payment with green status and transaction breakdown" />
+<img src="/images/transactions/payments/successful-payment.png" alt="Payment details page showing a successful payment with green status and transaction breakdown" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Status**: Shows as **Successful** at the top with the final captured amount.
@@ -53,7 +53,7 @@ Upon clicking a payment in the listing, merchants are directed to the **Payment 
 ### Failed payment
 
 <Frame caption="Example of a failed card payment with decline information">
-<img src="/images/transactions/payments/failed-payment.png" alt="Payment details page showing a failed payment with red error banner, decline error code and message" />
+<img src="/images/transactions/payments/failed-payment.png" alt="Payment details page showing a failed payment with red error banner, decline error code and message" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 - **Status**: Shows as **Failed** with a red banner.

--- a/features/transactions/refunds.mdx
+++ b/features/transactions/refunds.mdx
@@ -15,7 +15,7 @@ You can initiate two types of refunds from the Payment Details Page:
 To begin, click the **Initiate Refund** button. The refund will only proceed if all refund rules are met.
 
 <Frame>
-  <img src="/images/transactions/refunds/initiate-refund.png" alt="Initiate refund button on the payment details page" />
+  <img src="/images/transactions/refunds/initiate-refund.png" alt="Initiate refund button on the payment details page" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Tip>
@@ -61,7 +61,7 @@ The **Refunds Page** provides a detailed view of all refund transactions:&#x20;
 Here’s how the **Refunds Page** looks:
 
 <Frame>
-  <img src="/images/transactions/refunds/refunds-page.png" alt="Refunds page showing a list of refund transactions" />
+  <img src="/images/transactions/refunds/refunds-page.png" alt="Refunds page showing a list of refund transactions" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 
 ## Refund Receipt
@@ -71,7 +71,7 @@ Once a refund is successfully processed, a **Refund Receipt** is automatically s
 **Refund Receipt Template:**
 
 <Frame>
-  <img src="/images/transactions/refunds/refund-receipt-template.png" width="50%" alt="Refund receipt template showing the refund details" />
+  <img src="/images/transactions/refunds/refund-receipt-template.png" width="50%" alt="Refund receipt template showing the refund details" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 The refund receipt includes:

--- a/features/usage-based-billing/introduction.mdx
+++ b/features/usage-based-billing/introduction.mdx
@@ -55,7 +55,7 @@ Meters aggregate events into billable quantities:
 - **Last**: Most recent value
 
 <Frame>
-<img src="/images/usage-based/UBB-2.png" alt="Create meter interface" />
+<img src="/images/usage-based/UBB-2.png" alt="Create meter interface" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Products with Usage Pricing
@@ -63,7 +63,7 @@ Meters aggregate events into billable quantities:
 Set pricing per unit and optional free thresholds:
 
 <Frame>
-<img src="/images/usage-based/UBB-4.png" alt="Pricing configuration" />
+<img src="/images/usage-based/UBB-4.png" alt="Pricing configuration" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Example**: 2,500 calls - 1,000 free = 1,500 × $0.02 = $30.00
@@ -87,7 +87,7 @@ In your dashboard: **Meters** → **Create Meter**
 Link meter to a product with pricing:
 
 <Frame>
-<img src="/images/usage-based/UBB-5.png" alt="Adding meter to product" />
+<img src="/images/usage-based/UBB-5.png" alt="Adding meter to product" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 1. Select **Usage-Based Billing**
@@ -117,7 +117,7 @@ await fetch('https://test.dodopayments.com/events/ingest', {
 
 <Step title="Monitor Usage">
 <Frame>
-<img src="/images/guides/usage-based-billing/meter-quantities-chart.png" alt="Meter dashboard" />
+<img src="/images/guides/usage-based-billing/meter-quantities-chart.png" alt="Meter dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Check your meter's dashboard to see events and usage aggregation. Customers are billed automatically each cycle.

--- a/features/usage-based-billing/meters.mdx
+++ b/features/usage-based-billing/meters.mdx
@@ -10,7 +10,7 @@ Meters convert raw events into billable quantities. They filter events and apply
 </Info>
 
 <Frame>
-<img src="/images/usage-based/UBB-2.png" alt="Meter creation interface showing event name, aggregation type, and filtering options" />
+<img src="/images/usage-based/UBB-2.png" alt="Meter creation interface showing event name, aggregation type, and filtering options" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## API Resources
@@ -75,7 +75,7 @@ Unit label for invoices. Examples: `calls`, `tokens`, `GB`, `hours`
 
 <Step title="Filtering (Optional)">
 <Frame>
-<img src="/images/usage-based/UBB-3.png" alt="Event filtering" />
+<img src="/images/usage-based/UBB-3.png" alt="Event filtering" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Add conditions to filter which events are counted:
@@ -95,7 +95,7 @@ Review configuration and click **Create Meter**.
 ## Viewing Analytics
 
 <Frame>
-<img src="/images/usage-based/UBB-1.png" alt="Meter analytics" />
+<img src="/images/usage-based/UBB-1.png" alt="Meter analytics" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Your meter dashboard shows:
@@ -141,7 +141,7 @@ Click the **+** button to attach a meter. Configure the event name, aggregation 
 Toggle **Bill usage in Credits** on the meter configuration. This reveals the credit settings:
 
 <Frame caption="Toggle 'Bill usage in Credits' to switch from currency-based to credit-based deduction.">
-<img src="/images/CBB/Desktop - Attach Credit - UBB-5.jpg" alt="Meter configuration with Bill usage in Credits toggle enabled" />
+<img src="/images/CBB/Desktop - Attach Credit - UBB-5.jpg" alt="Meter configuration with Bill usage in Credits toggle enabled" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <ParamField path="Credit Entitlement" type="string" required>

--- a/integrations/autosend.mdx
+++ b/integrations/autosend.mdx
@@ -24,7 +24,7 @@ Follow these steps to integrate AutoSend with Dodo Payments:
   Navigate to the Webhooks section in your Dodo Payments dashboard.
   
   <Frame>
-    <img src="/images/integrations/autosend.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/autosend.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/close-crm.mdx
+++ b/integrations/close-crm.mdx
@@ -19,7 +19,7 @@ This integration requires a Close CRM API key with appropriate permissions.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/close-crm.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/close-crm.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/customer-io.mdx
+++ b/integrations/customer-io.mdx
@@ -19,7 +19,7 @@ This integration requires your Customer.io Site ID and API Key.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/customer-io.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/customer-io.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/datafast.mdx
+++ b/integrations/datafast.mdx
@@ -122,7 +122,7 @@ Configure a webhook endpoint to send payment data to DataFast's Payment API when
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/datafast/add.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/datafast/add.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
@@ -133,7 +133,7 @@ Configure a webhook endpoint to send payment data to DataFast's Payment API when
 <Step title="Enter API Key">
   Provide your DataFast API Key in the configuration field.
   <Frame>
-    <img src="/images/integrations/datafast/api-key.png" alt="Add API Key" />
+    <img src="/images/integrations/datafast/api-key.png" alt="Add API Key" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/discord.mdx
+++ b/integrations/discord.mdx
@@ -19,7 +19,7 @@ This guide assumes you have access to the Integrations section of the Dodo Payme
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, open <b>Webhooks → + Add Endpoint</b> and expand the dropdown to reveal integrations.
   <Frame>
-    <img src="/images/integrations/discord.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/discord.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/dub.mdx
+++ b/integrations/dub.mdx
@@ -224,7 +224,7 @@ Configure a webhook endpoint to send sale data to Dub's Track API when payments 
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to **Webhooks → + Add Endpoint** and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/dub/add.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/dub/add.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
@@ -235,7 +235,7 @@ Configure a webhook endpoint to send sale data to Dub's Track API when payments 
 <Step title="Enter API Key">
   Provide your Dub API Key in the configuration field.
   <Frame>
-    <img src="/images/integrations/dub/api-key.png" alt="Add API Key" />
+    <img src="/images/integrations/dub/api-key.png" alt="Add API Key" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/hubspot.mdx
+++ b/integrations/hubspot.mdx
@@ -19,7 +19,7 @@ This integration requires HubSpot admin access to configure OAuth scopes and API
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, go to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/hubspot.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/hubspot.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/inngest.mdx
+++ b/integrations/inngest.mdx
@@ -19,7 +19,7 @@ This integration requires your Inngest webhook URL from your function configurat
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/inngest.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/inngest.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/loops.mdx
+++ b/integrations/loops.mdx
@@ -19,7 +19,7 @@ This integration requires your Loops API Key for authentication.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/loops.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/loops.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/mailerlite.mdx
+++ b/integrations/mailerlite.mdx
@@ -21,7 +21,7 @@ This integration requires your MailerLite API Key for authentication. You can ge
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/mailerlite.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/mailerlite.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/microsoft-teams.mdx
+++ b/integrations/microsoft-teams.mdx
@@ -19,7 +19,7 @@ This guide assumes you have admin access to create webhooks in your Microsoft Te
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/teams.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/teams.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/n8n.mdx
+++ b/integrations/n8n.mdx
@@ -19,7 +19,7 @@ This integration requires an N8N webhook URL from your workflow configuration.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/n8n.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/n8n.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/raycast-extension.mdx
+++ b/integrations/raycast-extension.mdx
@@ -9,7 +9,7 @@ keywords: ["Dodo Payments", "Raycast", "Raycast extension", "productivity"]
   <img
     src="/images/integrations/raycast/dodo-payments-commands.png"
     alt="Raycast extension home showing Dodo Payments commands"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 Your Dodo Payments dashboard, a few keystrokes away. Use Raycast to quickly view payments, subscriptions, customers, products, discount codes, license keys, and refunds without opening the dashboard.
@@ -68,7 +68,7 @@ Browse recent payments and jump into detailed views in seconds.
   <img
     src="/images/integrations/raycast/view-payments.png"
     alt="Payments list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Subscriptions
@@ -79,7 +79,7 @@ Quickly scan active, trialing, and canceled subscriptions.
   <img
     src="/images/integrations/raycast/view-subscriptions.png"
     alt="Subscriptions list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Customers
@@ -90,7 +90,7 @@ Find customers fast and open full profiles.
   <img
     src="/images/integrations/raycast/view-customers.png"
     alt="Customers list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Products
@@ -101,7 +101,7 @@ Review and manage your product catalog at a glance.
   <img
     src="/images/integrations/raycast/view-products.png"
     alt="Products list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Discount Codes
@@ -112,7 +112,7 @@ Search and reference active discount codes quickly.
   <img
     src="/images/integrations/raycast/view-discount-codes.png"
     alt="Discount codes list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### License Keys
@@ -123,7 +123,7 @@ Look up and manage license keys without leaving Raycast.
   <img
     src="/images/integrations/raycast/view-license-keys.png"
     alt="License keys list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Refunds
@@ -134,7 +134,7 @@ See recent refunds and drill into their details.
   <img
     src="/images/integrations/raycast/view-refunds.png"
     alt="Refunds list view in the Raycast extension"
-  />
+  style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 <Info>

--- a/integrations/resend.mdx
+++ b/integrations/resend.mdx
@@ -19,7 +19,7 @@ This integration requires your Resend API Key for authentication.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/resend.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/resend.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/segment.mdx
+++ b/integrations/segment.mdx
@@ -19,7 +19,7 @@ This integration requires a Segment Write Key from your Segment workspace.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/segment.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/segment.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/sendgrid.mdx
+++ b/integrations/sendgrid.mdx
@@ -19,7 +19,7 @@ This integration requires a SendGrid API Key with Mail Send permissions.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/sendgrid.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/sendgrid.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/slack.mdx
+++ b/integrations/slack.mdx
@@ -19,35 +19,35 @@ This integration uses our webhook management portal to automatically transform D
 <Step title="Open the Webhook Section">
   Go to the <b>Webhook</b> section in your Dodo Payments dashboard. Click the <b>+ Add Endpoint</b> button, then open the webhook dropdown to reveal other integrations.
   <Frame>
-    <img src="/images/integrations/slack/1.png" alt="Dodo Payments dashboard showing Add Endpoint button and integrations dropdown" />
+    <img src="/images/integrations/slack/1.png" alt="Dodo Payments dashboard showing Add Endpoint button and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
 <Step title="Select Slack Integration">
   Select the <b>Slack</b> integration and click <b>Connect your Slack workspace</b>.
   <Frame>
-    <img src="/images/integrations/slack/2.png" alt="Slack integration card and connect button" />
+    <img src="/images/integrations/slack/2.png" alt="Slack integration card and connect button" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
 <Step title="Grant Slack Permissions">
   Grant the necessary permissions to the Incoming Webhooks Slack App so it can post messages in your chosen channel.
   <Frame>
-    <img src="/images/integrations/slack/3.png" alt="Slack OAuth permissions screen for Incoming Webhooks app" />
+    <img src="/images/integrations/slack/3.png" alt="Slack OAuth permissions screen for Incoming Webhooks app" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
 <Step title="Customize Transformation Code">
   Add or edit the transformation code to customize your Slack notifications for your use case. You can use the pre-made templates or write your own logic.
   <Frame>
-    <img src="/images/integrations/slack/4.png" alt="Transformation code editor for Slack integration" />
+    <img src="/images/integrations/slack/4.png" alt="Transformation code editor for Slack integration" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 
 <Step title="Test and Create">
   Test your transformation code with custom or pre-made event payloads. Once you're satisfied, click <b>Create</b> to activate the integration.
   <Frame>
-    <img src="/images/integrations/slack/5.png" alt="Test transformation and create button" />
+    <img src="/images/integrations/slack/5.png" alt="Test transformation and create button" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/windmill.mdx
+++ b/integrations/windmill.mdx
@@ -19,7 +19,7 @@ This integration requires your Windmill webhook URL from your workflow configura
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/windmill.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/windmill.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/integrations/woocommerce-plugin.mdx
+++ b/integrations/woocommerce-plugin.mdx
@@ -27,30 +27,30 @@ The Dodo Payments WooCommerce plugin provides a seamless integration with your s
 3. Navigate to **Plugins → Add New Plugin**
     
     <Frame>
-        <img src="/images/woocommerce/1.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/1.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 4. Click on the **Upload Plugin** button and a file selection dialog will appear
 
     <Frame>
-        <img src="/images/woocommerce/2.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/2.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
     <Frame>
-        <img src="/images/woocommerce/3.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/3.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 5. Click **Browse…** and select the zip file you downloaded
 6. Click the **Install Now** button to begin the installation process
     
     <Frame>
-        <img src="/images/woocommerce/4.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/4.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 7. After installation completes, click **Activate Plugin** or activate it from the **Installed Plugins** section
     
     <Frame>
-        <img src="/images/woocommerce/5.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/5.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 8. The plugin is now installed, but configuration is still required. Continue to the setup guide below.
@@ -62,77 +62,77 @@ The Dodo Payments WooCommerce plugin provides a seamless integration with your s
 1. Navigate to **WooCommerce → Settings → Payments** or click the **Payments** button in the left sidebar below the WooCommerce menu item
     
     <Frame>
-        <img src="/images/woocommerce/6.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/6.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
     <Frame>
-        <img src="/images/woocommerce/7.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/7.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 2. Enable the **Dodo Payments** payment provider if not already enabled, then click **Manage** to configure the plugin
 3. You'll see various configuration options, each with helpful explanatory text. Begin by setting up your Live API Key
     
     <Frame>
-        <img src="/images/woocommerce/8.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/8.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 4. Log in to your Dodo Payments dashboard in **Live Mode**, then navigate to **Dodo Payments (Live Mode) > Developer > API Keys** or visit [this direct link](https://app.dodopayments.com/developer/api-keys) and click **Add API Key**
     
     <Frame>
-        <img src="/images/woocommerce/9.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/9.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 5. Give your API Key a descriptive name and click **Create**
     
     <Frame>
-        <img src="/images/woocommerce/10.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/10.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 6. Copy the generated API Key and paste it into the **Live API Key** field in your WooCommerce plugin settings
     
     <Frame>
-        <img src="/images/woocommerce/11.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/11.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
     <Frame>
-        <img src="/images/woocommerce/12.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/12.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 7. Next, set up the Webhook Signing Key to enable payment status synchronization between Dodo Payments and WooCommerce
 8. Scroll to the bottom of the plugin settings page and copy the webhook URL displayed there
     
     <Frame>
-        <img src="/images/woocommerce/13.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/13.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 9. Return to your Dodo Payments dashboard and navigate to **Dodo Payments (Live Mode) > Developer > Webhooks** and click **Add Webhook**
     
     <Frame>
-        <img src="/images/woocommerce/14.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/14.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 10. Paste the URL you copied in step 8 into the dialog and click **Add Webhook**
     
     <Frame>
-        <img src="/images/woocommerce/15.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/15.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 11. After creating the webhook, click the eye icon next to the redacted **Signing Key** to reveal and copy it
     
     <Frame>
-        <img src="/images/woocommerce/16.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/16.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 12. Paste the Signing Key into the **Live Webhook Signing Key** field in your plugin settings and save the changes
     
     <Frame>
-        <img src="/images/woocommerce/17.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/17.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 13. Review the remaining settings such as **Global Tax Category** and **All Prices are Tax Inclusive**, as these options determine how products sync from WooCommerce to Dodo Payments. Note that **Test API Key** and **Test Webhook Signing Key** are only needed if you plan to use Test Mode
     
     <Frame>
-        <img src="/images/woocommerce/18.webp" alt="Dodo Payments for WooCommerce Plugin" />
+        <img src="/images/woocommerce/18.webp" alt="Dodo Payments for WooCommerce Plugin" style={{ maxHeight: '500px', width: 'auto' }} />
     </Frame>
     
 
@@ -141,13 +141,13 @@ The Dodo Payments WooCommerce plugin provides a seamless integration with your s
 Your WooCommerce store is now integrated with Dodo Payments! Customers can select Dodo Payments at checkout to access all supported payment methods.
 
 <Frame>
-    <img src="/images/woocommerce/19.webp" alt="Dodo Payments checkout option in WooCommerce" />
+    <img src="/images/woocommerce/19.webp" alt="Dodo Payments checkout option in WooCommerce" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 When customers choose Dodo Payments, they'll be seamlessly redirected to the Dodo Payments checkout page to complete their transaction.
 
 <Frame>
-    <img src="/images/woocommerce/20.webp" alt="Dodo Payments checkout page" />
+    <img src="/images/woocommerce/20.webp" alt="Dodo Payments checkout page" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## Key Features

--- a/integrations/zapier.mdx
+++ b/integrations/zapier.mdx
@@ -19,7 +19,7 @@ This integration requires a Zapier webhook URL from your Zap configuration.
 <Step title="Open the Webhook Section">
   In your Dodo Payments dashboard, navigate to <b>Webhooks → + Add Endpoint</b> and expand the integrations dropdown.
   <Frame>
-    <img src="/images/integrations/zapier.png" alt="Add Endpoint and integrations dropdown" />
+    <img src="/images/integrations/zapier.png" alt="Add Endpoint and integrations dropdown" style={{ maxHeight: '500px', width: 'auto' }} />
   </Frame>
 </Step>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ keywords: ["Dodo Payments", "welcome to dodo payments"]
 ---
 
 <Frame>
-  <img src="/images/intro_cover.png" alt="Dodo Payments - Complete payments and billing platform for modern digital products"/>
+  <img src="/images/intro_cover.png" alt="Dodo Payments - Complete payments and billing platform for modern digital products" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ## What is Dodo Payments?

--- a/miscellaneous/verification-process.mdx
+++ b/miscellaneous/verification-process.mdx
@@ -28,7 +28,7 @@ The Verification section is available in your dashboard.
 Complete the verification process after sign-up to receive access to live payments and enable payouts as soon as possible.
 
 <Frame>
-  <img src="/images/payouts/verification-process.png" alt="Verification Process"/>
+  <img src="/images/payouts/verification-process.png" alt="Verification Process" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Steps to Activate Payouts
@@ -290,19 +290,19 @@ The most important part of the document is the certification and signature. Here
 **Page 1**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 1.png" alt="W-8 BEN-E Private Limited Sample Page 1"/>
+  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 1.png" alt="W-8 BEN-E Private Limited Sample Page 1" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Page 2**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 2.png" alt="W-8 BEN-E Private Limited Sample Page 2"/>
+  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 2.png" alt="W-8 BEN-E Private Limited Sample Page 2" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Page 8**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 8.png" alt="W-8 BEN-E Private Limited Sample Page 8"/>
+  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 8.png" alt="W-8 BEN-E Private Limited Sample Page 8" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Accordion>
 
@@ -318,19 +318,19 @@ The most important part of the document is the certification and signature. Here
 **Page 1**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - LLP SAMPLE - 1.png" alt="W-8 BEN-E LLP Sample Page 1"/>
+  <img src="/images/tax-forms/W8 - BEN - LLP SAMPLE - 1.png" alt="W-8 BEN-E LLP Sample Page 1" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Page 2**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - LLP SAMPLE - 2.png" alt="W-8 BEN-E LLP Sample Page 2"/>
+  <img src="/images/tax-forms/W8 - BEN - LLP SAMPLE - 2.png" alt="W-8 BEN-E LLP Sample Page 2" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 **Page 8**
 
 <Frame>
-  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 8.png" alt="W-8 BEN-E LLP Sample Page 8"/>
+  <img src="/images/tax-forms/W8 - BEN - PLC - SAMPLE - 8.png" alt="W-8 BEN-E LLP Sample Page 8" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 </Accordion>
 </AccordionGroup>
@@ -360,7 +360,7 @@ Once the review is complete and everything looks good, payouts will be enabled f
 - You will be able to view your payout schedule, next payout date, payout threshold and eligible balance directly in the dashboard
 
 <Frame>
-  <img src="/images/payouts/payout-activation2.png" alt="Account Activated"/>
+  <img src="/images/payouts/payout-activation2.png" alt="Account Activated" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
 ### Ongoing Monitoring


### PR DESCRIPTION
## Summary

- Adds `maxHeight: '500px'` constraint to all `<img>` tags across 95 non-translated documentation pages
- Covers `features/`, `developer-resources/`, `integrations/`, `changelog/`, `miscellaneous/`, and root pages
- Translated locale directories (`es/`, `fr/`, `de/`, `ko/`, etc.) are intentionally untouched
- For images with existing `style` attributes (e.g. `width: '70%'`), `maxHeight` is merged into the existing style
- The original email screenshots were 1070×1500px portrait, rendering excessively tall — this caps all images at 500px height