### PR TITLE
docs: add POST /license_keys (create license key) API endpoint

### DIFF
--- a/api-reference/licenses/create-license-key.mdx
+++ b/api-reference/licenses/create-license-key.mdx
@@ -1,0 +1,6 @@
+---
+title: Create License Key
+description: Create a new license key or import an existing one from another system.
+keywords: ["Dodo Payments", "API reference", "REST API", "create license key", "import license key"]
+openapi: post /license_keys
+---

--- a/docs.json
+++ b/docs.json
@@ -423,6 +423,7 @@
               {
                 "group": "Licenses",
                 "pages": [
+                  "api-reference/licenses/create-license-key",
                   "api-reference/licenses/activate-license",
                   "api-reference/licenses/deactivate-license",
                   "api-reference/licenses/validate-license",

--- a/features/license-keys.mdx
+++ b/features/license-keys.mdx
@@ -61,6 +61,45 @@ License keys are unique tokens that authorize access to your product. They're id
     <img src="/images/license-keys/1.webp" alt="Creating a license key in Dodo Payments dashboard" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
 
+## Import License Keys via API
+
+Already have license keys in another system? Use the [Create License Key](/api-reference/licenses/create-license-key) API to import them into Dodo Payments. This lets you migrate existing keys without disrupting your customers.
+
+<CodeGroup>
+```typescript TypeScript/Node.js
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments();
+
+const licenseKey = await client.licenseKeys.create({
+  customer_id: 'cust_123',
+  product_id: 'prod_456',
+  key: 'YOUR-EXISTING-LICENSE-KEY',
+  activations_limit: 5,
+  expires_at: '2026-12-31T23:59:59Z',
+});
+
+console.log(licenseKey.id);
+```
+
+```bash cURL
+curl -X POST https://live.dodopayments.com/license_keys \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "cust_123",
+    "product_id": "prod_456",
+    "key": "YOUR-EXISTING-LICENSE-KEY",
+    "activations_limit": 5,
+    "expires_at": "2026-12-31T23:59:59Z"
+  }'
+```
+</CodeGroup>
+
+<Tip>
+You can also use this endpoint to programmatically create new license keys with custom values, activation limits, and expiry dates — useful for bulk provisioning or enterprise licensing workflows.
+</Tip>
+
 ## Manage & Monitor
 
 The **License Keys Section** provides a comprehensive view of all license key activity and enables you to manage and monitor licenses effectively.
@@ -97,7 +136,7 @@ You can perform the following actions on license keys:
 
 ## API Management
 
-Use these APIs to activate, validate, list, and update license keys and their activation instances.
+Use these APIs to create, activate, validate, list, and update license keys and their activation instances.
 
 <Info>
 **Public Endpoints**: The activate, deactivate, and validate license endpoints are **public** and do **not require an API key**. This allows you to call them directly from your client applications, desktop software, or CLIs without exposing your API credentials.
@@ -123,9 +162,13 @@ Check authenticity, status, and constraints before granting access.
 </Accordion>
 
 <Accordion title="License Key Management">
-List, retrieve, and update license keys with their settings and status.
+Create, list, retrieve, and update license keys with their settings and status.
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
+<Card title="Create License Key" icon="code" href="/api-reference/licenses/create-license-key">
+Create a new license key or import an existing one from another system.
+</Card>
+
 <Card title="List License Keys" icon="code" href="/api-reference/licenses/list-license-keys">
 Browse all keys with status and usage details.
 </Card>
@@ -213,6 +256,37 @@ curl -X POST https://test.dodopayments.com/licenses/validate \
   -H "Content-Type: application/json" \
   -d '{
     "license_key": "2b1f8e2d-c41e-4e8f-b2d3-d9fd61c38f43"
+  }'
+```
+</CodeGroup>
+
+### Create a license key
+
+<CodeGroup>
+```typescript TypeScript/Node.js
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({
+  bearerToken: process.env['DODO_PAYMENTS_API_KEY'],
+});
+
+const licenseKey = await client.licenseKeys.create({
+  customer_id: 'cust_123',
+  product_id: 'prod_456',
+  key: 'MY-CUSTOM-KEY-001',
+});
+
+console.log(licenseKey.id);
+```
+
+```bash cURL
+curl -X POST https://live.dodopayments.com/license_keys \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customer_id": "cust_123",
+    "product_id": "prod_456",
+    "key": "MY-CUSTOM-KEY-001"
   }'
 ```
 </CodeGroup>

--- a/openapi/openapi.documented.yml
+++ b/openapi/openapi.documented.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
-  version: 1.94.2
+  version: 1.95.3
 servers:
   - url: https://test.dodopayments.com/
     description: Test Mode Server Host
@@ -5998,6 +5998,225 @@ paths:
             get_dispute = dodo_payments.disputes.retrieve("dispute_id")
 
             puts(get_dispute)
+  /entitlements:
+    get:
+      tags:
+        - Entitlements
+      summary: GET /entitlements
+      operationId: list_entitlements_public_handler
+      parameters:
+        - name: page_size
+          in: query
+          description: Page size (default 10, max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+          style: form
+        - name: page_number
+          in: query
+          description: Page number (default 0)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+          style: form
+        - name: integration_type
+          in: query
+          description: Filter by integration type
+          required: false
+          schema:
+            type: string
+            enum:
+              - discord
+              - telegram
+              - github
+              - figma
+              - framer
+              - notion
+              - digital_files
+              - license_key
+          style: form
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEntitlementsResponse'
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
+    post:
+      tags:
+        - Entitlements
+      summary: POST /entitlements
+      operationId: create_entitlement_public_handler
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEntitlementRequest'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitlementResponse'
+        '422':
+          description: Invalid request
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
+  /entitlements/{id}:
+    get:
+      tags:
+        - Entitlements
+      summary: GET /entitlements/{id}
+      operationId: get_entitlement_public_handler
+      parameters:
+        - name: id
+          in: path
+          description: Entitlement ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitlementResponse'
+        '404':
+          description: Not found
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
+    delete:
+      tags:
+        - Entitlements
+      summary: DELETE /entitlements/{id} (soft-delete)
+      operationId: delete_entitlement_public_handler
+      parameters:
+        - name: id
+          in: path
+          description: Entitlement ID
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Entitlement deactivated
+        '404':
+          description: Not found
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
+    patch:
+      tags:
+        - Entitlements
+      summary: PATCH /entitlements/{id}
+      operationId: patch_entitlement_public_handler
+      parameters:
+        - name: id
+          in: path
+          description: Entitlement ID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchEntitlementRequest'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitlementResponse'
+        '404':
+          description: Not found
+        '422':
+          description: Invalid request
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
+  /entitlements/{id}/grants:
+    get:
+      tags:
+        - Entitlements
+      summary: GET /entitlements/{id}/grants (public API)
+      operationId: list_grants_public_handler
+      parameters:
+        - name: id
+          in: path
+          description: Entitlement ID
+          required: true
+          schema:
+            type: string
+        - name: page_size
+          in: query
+          description: Page size (default 10, max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+          style: form
+        - name: page_number
+          in: query
+          description: Page number (default 0)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+          style: form
+        - name: status
+          in: query
+          description: Filter by grant status
+          required: false
+          schema:
+            type: string
+            enum:
+              - Pending
+              - Delivered
+              - Failed
+              - Revoked
+          style: form
+        - name: customer_id
+          in: query
+          description: Filter by customer ID
+          required: false
+          schema:
+            type: string
+          style: form
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEntitlementGrantsResponse'
+        '404':
+          description: Entitlement not found
+        '500':
+          description: Something went wrong
+      security:
+        - API_KEY: []
   /events:
     get:
       tags:
@@ -7270,6 +7489,16 @@ paths:
             type: string
             format: date-time
           style: form
+        - name: source
+          in: query
+          description: Filter by license key source
+          required: false
+          schema:
+            type: string
+            enum:
+              - auto
+              - import
+          style: form
       responses:
         '200':
           description: ''
@@ -7279,6 +7508,7 @@ paths:
                 $ref: '#/components/schemas/ListLicenseKeysResponse'
         '500':
           description: Something went wrong :(
+      deprecated: true
       security:
         - API_KEY: []
       x-codeSamples:
@@ -7351,6 +7581,135 @@ paths:
             page = dodo_payments.license_keys.list
 
             puts(page)
+    post:
+      tags:
+        - License Keys
+      operationId: create_license_key
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateLicenseKeyRequest'
+        required: true
+      responses:
+        '201':
+          description: License key created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LicenseKeyResponse'
+        '404':
+          description: Customer or product not found
+        '409':
+          description: License key already exists
+        '422':
+          description: Validation error
+        '500':
+          description: Something went wrong :(
+      security:
+        - API_KEY: []
+      x-codeSamples:
+        - lang: JavaScript
+          source: |-
+            import DodoPayments from 'dodopayments';
+
+            const client = new DodoPayments({
+              bearerToken: process.env['DODO_PAYMENTS_API_KEY'], // This is the default and can be omitted
+            });
+
+            const licenseKey = await client.licenseKeys.create({
+              customer_id: 'customer_id',
+              key: 'key',
+              product_id: 'product_id',
+            });
+
+            console.log(licenseKey.id);
+        - lang: Python
+          source: |-
+            import os
+            from dodopayments import DodoPayments
+
+            client = DodoPayments(
+                bearer_token=os.environ.get("DODO_PAYMENTS_API_KEY"),  # This is the default and can be omitted
+            )
+            license_key = client.license_keys.create(
+                customer_id="customer_id",
+                key="key",
+                product_id="product_id",
+            )
+            print(license_key.id)
+        - lang: Go
+          source: "package main\n\nimport (\n\t\"context\"\n\t\"fmt\"\n\n\t\"github.com/dodopayments/dodopayments-go\"\n\t\"github.com/dodopayments/dodopayments-go/option\"\n)\n\nfunc main() {\n\tclient := dodopayments.NewClient(\n\t\toption.WithBearerToken(\"My Bearer Token\"),\n\t)\n\tlicenseKey, err := client.LicenseKeys.New(context.TODO(), dodopayments.LicenseKeyNewParams{\n\t\tCustomerID: dodopayments.F(\"customer_id\"),\n\t\tKey:        dodopayments.F(\"key\"),\n\t\tProductID:  dodopayments.F(\"product_id\"),\n\t})\n\tif err != nil {\n\t\tpanic(err.Error())\n\t}\n\tfmt.Printf(\"%+v\\n\", licenseKey.ID)\n}\n"
+        - lang: Java
+          source: >-
+            package com.dodopayments.api.example;
+
+
+            import com.dodopayments.api.client.DodoPaymentsClient;
+
+            import com.dodopayments.api.client.okhttp.DodoPaymentsOkHttpClient;
+
+            import com.dodopayments.api.models.licensekeys.LicenseKey;
+
+            import
+            com.dodopayments.api.models.licensekeys.LicenseKeyCreateParams;
+
+
+            public final class Main {
+                private Main() {}
+
+                public static void main(String[] args) {
+                    DodoPaymentsClient client = DodoPaymentsOkHttpClient.fromEnv();
+
+                    LicenseKeyCreateParams params = LicenseKeyCreateParams.builder()
+                        .customerId("customer_id")
+                        .key("key")
+                        .productId("product_id")
+                        .build();
+                    LicenseKey licenseKey = client.licenseKeys().create(params);
+                }
+            }
+        - lang: Kotlin
+          source: >-
+            package com.dodopayments.api.example
+
+
+            import com.dodopayments.api.client.DodoPaymentsClient
+
+            import com.dodopayments.api.client.okhttp.DodoPaymentsOkHttpClient
+
+            import com.dodopayments.api.models.licensekeys.LicenseKey
+
+            import
+            com.dodopayments.api.models.licensekeys.LicenseKeyCreateParams
+
+
+            fun main() {
+                val client: DodoPaymentsClient = DodoPaymentsOkHttpClient.fromEnv()
+
+                val params: LicenseKeyCreateParams = LicenseKeyCreateParams.builder()
+                    .customerId("customer_id")
+                    .key("key")
+                    .productId("product_id")
+                    .build()
+                val licenseKey: LicenseKey = client.licenseKeys().create(params)
+            }
+        - lang: Ruby
+          source: >-
+            require "dodopayments"
+
+
+            dodo_payments = Dodopayments::Client.new(
+              bearer_token: "My Bearer Token",
+              environment: "test_mode" # defaults to "live_mode"
+            )
+
+
+            license_key = dodo_payments.license_keys.create(customer_id:
+            "customer_id", key: "key", product_id: "product_id")
+
+
+            puts(license_key)
   /license_keys/{id}:
     get:
       tags:
@@ -7375,6 +7734,7 @@ paths:
           description: License key not found
         '500':
           description: Something went wrong :(
+      deprecated: true
       security:
         - API_KEY: []
       x-codeSamples:
@@ -7492,6 +7852,7 @@ paths:
           description: New activation limit is less than current instances count
         '500':
           description: Something went wrong :(
+      deprecated: true
       security:
         - API_KEY: []
       x-codeSamples:
@@ -15306,6 +15667,32 @@ components:
           description: |-
             How many times this discount can be used (if any).
             Must be >= 1 if provided.
+    CreateEntitlementRequest:
+      type: object
+      required:
+        - name
+        - integration_type
+        - integration_config
+      properties:
+        description:
+          type:
+            - string
+            - 'null'
+          description: Optional description
+        integration_config:
+          $ref: '#/components/schemas/IntegrationConfig'
+          description: Platform-specific configuration (validated per integration_type)
+        integration_type:
+          $ref: '#/components/schemas/EntitlementIntegrationType'
+          description: Which platform integration this entitlement uses
+        metadata:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Metadata'
+              description: Optional user-facing metadata
+        name:
+          type: string
+          description: Display name for this entitlement
     CreateLedgerEntryRequest:
       type: object
       description: Request to create a ledger entry (credit or debit)
@@ -15389,6 +15776,34 @@ components:
           type:
             - string
             - 'null'
+    CreateLicenseKeyRequest:
+      type: object
+      required:
+        - key
+        - customer_id
+        - product_id
+      properties:
+        activations_limit:
+          type:
+            - integer
+            - 'null'
+          format: int32
+          description: Maximum number of activations allowed. Null means unlimited.
+        customer_id:
+          type: string
+          description: The customer this license key belongs to.
+        expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          description: Expiration timestamp. Null means the key never expires.
+        key:
+          type: string
+          description: The license key string to import.
+        product_id:
+          type: string
+          description: The product this license key is for.
     CreateMeterRequest:
       type: object
       required:
@@ -15672,11 +16087,19 @@ components:
             - type: 'null'
             - $ref: '#/components/schemas/CreateDigitalProductDeliveryRequest'
               description: Choose how you would like you digital product delivered
+        entitlement_ids:
+          type:
+            - array
+            - 'null'
+          items:
+            type: string
+          description: Optional entitlement IDs to attach to this product (max 20)
         license_key_activation_message:
           type:
             - string
             - 'null'
           description: Optional message displayed during license key activation
+          deprecated: true
         license_key_activations_limit:
           type:
             - integer
@@ -15685,6 +16108,7 @@ components:
           description: |-
             The number of times the license key can be activated.
             Must be 0 or greater
+          deprecated: true
         license_key_duration:
           oneOf:
             - type: 'null'
@@ -15703,6 +16127,7 @@ components:
           description: |-
             When true, generates and sends a license key to your customer.
             Defaults to false
+          deprecated: true
         metadata:
           $ref: '#/components/schemas/Metadata'
           description: Additional metadata for the product
@@ -17395,6 +17820,155 @@ components:
       enum:
         - immediately
         - next_billing_date
+    EntitlementGrantResponse:
+      type: object
+      required:
+        - id
+        - business_id
+        - entitlement_id
+        - customer_id
+        - external_id
+        - status
+        - created_at
+        - updated_at
+      properties:
+        business_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        customer_id:
+          type: string
+        delivered_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        entitlement_id:
+          type: string
+        error_code:
+          type:
+            - string
+            - 'null'
+        error_message:
+          type:
+            - string
+            - 'null'
+        external_id:
+          type: string
+        id:
+          type: string
+        license_key:
+          type:
+            - string
+            - 'null'
+        license_key_activations_limit:
+          type:
+            - integer
+            - 'null'
+          format: int32
+        license_key_activations_used:
+          type:
+            - integer
+            - 'null'
+          format: int32
+        license_key_expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        license_key_status:
+          type:
+            - string
+            - 'null'
+        metadata: {}
+        oauth_expires_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        oauth_url:
+          type:
+            - string
+            - 'null'
+        payment_id:
+          type:
+            - string
+            - 'null'
+        revocation_reason:
+          type:
+            - string
+            - 'null'
+        revoked_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        status:
+          $ref: '#/components/schemas/EntitlementGrantStatus'
+        subscription_id:
+          type:
+            - string
+            - 'null'
+        updated_at:
+          type: string
+          format: date-time
+    EntitlementGrantStatus:
+      type: string
+      enum:
+        - Pending
+        - Delivered
+        - Failed
+        - Revoked
+    EntitlementIntegrationType:
+      type: string
+      enum:
+        - discord
+        - telegram
+        - github
+        - figma
+        - framer
+        - notion
+        - digital_files
+        - license_key
+    EntitlementResponse:
+      type: object
+      required:
+        - id
+        - business_id
+        - integration_type
+        - name
+        - integration_config
+        - is_active
+        - created_at
+        - updated_at
+      properties:
+        business_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        description:
+          type:
+            - string
+            - 'null'
+        id:
+          type: string
+        integration_config:
+          $ref: '#/components/schemas/IntegrationConfig'
+        integration_type:
+          $ref: '#/components/schemas/EntitlementIntegrationType'
+        is_active:
+          type: boolean
+        metadata:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Value'
+        name:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
     Event:
       type: object
       required:
@@ -17519,6 +18093,10 @@ components:
         - dunning.recovered
         - acr.email
         - dunning.email
+        - entitlement_grant.created
+        - entitlement_grant.delivered
+        - entitlement_grant.failed
+        - entitlement_grant.revoked
     FailedEvent:
       type: object
       required:
@@ -18029,6 +18607,7 @@ components:
         - brand_id
         - metadata
         - credit_entitlements
+        - entitlements
       properties:
         addons:
           type:
@@ -18060,6 +18639,11 @@ components:
           oneOf:
             - type: 'null'
             - $ref: '#/components/schemas/DigitalProductDelivery'
+        entitlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductEntitlementSummary'
+          description: Attached entitlements (integration-based access grants)
         image:
           type:
             - string
@@ -18073,12 +18657,14 @@ components:
             - string
             - 'null'
           description: Message sent upon license key activation, if applicable.
+          deprecated: true
         license_key_activations_limit:
           type:
             - integer
             - 'null'
           format: int32
           description: Limit on the number of activations for the license key, if enabled.
+          deprecated: true
         license_key_duration:
           oneOf:
             - type: 'null'
@@ -18087,6 +18673,7 @@ components:
         license_key_enabled:
           type: boolean
           description: Indicates whether the product requires a license key.
+          deprecated: true
         metadata:
           $ref: '#/components/schemas/Metadata'
           description: Additional custom data associated with the product
@@ -18132,6 +18719,7 @@ components:
         - is_recurring
         - tax_category
         - metadata
+        - entitlements
       properties:
         business_id:
           type: string
@@ -18150,6 +18738,11 @@ components:
             - string
             - 'null'
           description: Description of the product, optional.
+        entitlements:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductEntitlementSummary'
+          description: Entitlements linked to this product
         image:
           type:
             - string
@@ -18315,6 +18908,101 @@ components:
         ingested_count:
           type: integer
           minimum: 0
+    IntegrationConfig:
+      oneOf:
+        - type: object
+          title: Github Config
+          required:
+            - target_id
+            - permission
+          properties:
+            permission:
+              type: string
+              description: 'One of: pull, push, admin, maintain, triage'
+            target_id:
+              type: string
+        - type: object
+          title: Discord Config
+          required:
+            - guild_id
+          properties:
+            guild_id:
+              type: string
+            role_id:
+              type:
+                - string
+                - 'null'
+        - type: object
+          title: Telegram Config
+          required:
+            - chat_id
+          properties:
+            chat_id:
+              type: string
+        - type: object
+          title: Figma Config
+          required:
+            - figma_file_id
+          properties:
+            figma_file_id:
+              type: string
+        - type: object
+          title: Framer Config
+          required:
+            - framer_template_id
+          properties:
+            framer_template_id:
+              type: string
+        - type: object
+          title: Notion Config
+          required:
+            - notion_template_id
+          properties:
+            notion_template_id:
+              type: string
+        - type: object
+          title: Digital Files Config
+          required:
+            - digital_file_ids
+          properties:
+            digital_file_ids:
+              type: array
+              items:
+                type: string
+            external_url:
+              type:
+                - string
+                - 'null'
+            instructions:
+              type:
+                - string
+                - 'null'
+        - type: object
+          title: License Key Config
+          properties:
+            activation_message:
+              type:
+                - string
+                - 'null'
+            activations_limit:
+              type:
+                - integer
+                - 'null'
+              format: int32
+            duration_count:
+              type:
+                - integer
+                - 'null'
+              format: int32
+            duration_interval:
+              type:
+                - string
+                - 'null'
+      description: >-
+        Platform-specific configuration for an entitlement.
+
+        Each variant uses unique field names so `#[serde(untagged)]` can
+        disambiguate correctly.
     IntentStatus:
       type: string
       enum:
@@ -18402,9 +19090,9 @@ components:
         - status
         - customer_id
         - product_id
-        - payment_id
         - instances_count
         - created_at
+        - source
       properties:
         activations_limit:
           type:
@@ -18448,15 +19136,22 @@ components:
           type: string
           description: The license key string.
         payment_id:
-          type: string
+          type:
+            - string
+            - 'null'
           description: >-
             The unique identifier of the payment associated with the license
-            key.
+            key, if any.
         product_id:
           type: string
           description: >-
             The unique identifier of the product associated with the license
             key.
+        source:
+          $ref: '#/components/schemas/LicenseKeySource'
+          description: >-
+            The source of the license key - 'auto' for keys generated by
+            payment/subscription flows, 'import' for merchant-imported keys.
         status:
           $ref: '#/components/schemas/LicenseKeyStatus'
           description: >-
@@ -18469,6 +19164,11 @@ components:
           description: >-
             The unique identifier of the subscription associated with the
             license key, if any.
+    LicenseKeySource:
+      type: string
+      enum:
+        - auto
+        - import
     LicenseKeyStatus:
       type: string
       enum:
@@ -18752,6 +19452,24 @@ components:
         payment_id:
           type: string
           description: The unique identifier of the payment associated with the dispute.
+    ListEntitlementGrantsResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntitlementGrantResponse'
+    ListEntitlementsResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntitlementResponse'
     ListGrantsResponse:
       type: object
       required:
@@ -19447,6 +20165,17 @@ components:
                   enum:
                     - DunningAttempt
           title: Dunning Attempt
+        - allOf:
+            - $ref: '#/components/schemas/EntitlementGrantResponse'
+            - type: object
+              required:
+                - payload_type
+              properties:
+                payload_type:
+                  type: string
+                  enum:
+                    - EntitlementGrant
+          title: Entitlement Grant
     PartialRefundItem:
       type: object
       required:
@@ -19730,6 +20459,25 @@ components:
             - integer
             - 'null'
           format: int32
+    PatchEntitlementRequest:
+      type: object
+      properties:
+        description:
+          type:
+            - string
+            - 'null'
+        integration_config:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/IntegrationConfig'
+        metadata:
+          oneOf:
+            - type: 'null'
+            - $ref: '#/components/schemas/Metadata'
+        name:
+          type:
+            - string
+            - 'null'
     PatchLicenseKeyInstanceRequest:
       type: object
       required:
@@ -19873,6 +20621,15 @@ components:
             - type: 'null'
             - $ref: '#/components/schemas/PatchDigitalProductDeliveryRequest'
               description: Choose how you would like you digital product delivered
+        entitlement_ids:
+          type:
+            - array
+            - 'null'
+          items:
+            type: string
+          description: |-
+            Entitlement IDs to attach (replaces all existing when present)
+            Send empty array to remove all, omit field to leave unchanged
         image_id:
           type:
             - string
@@ -19891,6 +20648,7 @@ components:
             contains instructions for
 
             activating the license key.
+          deprecated: true
         license_key_activations_limit:
           type:
             - integer
@@ -19904,6 +20662,7 @@ components:
             maximum number of times
 
             the license key can be activated.
+          deprecated: true
         license_key_duration:
           oneOf:
             - type: 'null'
@@ -19928,6 +20687,7 @@ components:
             activations limit, activation message)
 
             become applicable.
+          deprecated: true
         metadata:
           oneOf:
             - type: 'null'
@@ -20826,6 +21586,27 @@ components:
           type: string
           format: date-time
           description: Timestamp when the collection was last updated
+    ProductEntitlementSummary:
+      type: object
+      description: Summary of an entitlement attached to a product
+      required:
+        - id
+        - integration_type
+        - name
+        - integration_config
+      properties:
+        description:
+          type:
+            - string
+            - 'null'
+        id:
+          type: string
+        integration_config:
+          $ref: '#/components/schemas/IntegrationConfig'
+        integration_type:
+          $ref: '#/components/schemas/EntitlementIntegrationType'
+        name:
+          type: string
     ProductItemReq:
       type: object
       title: Product Item Request
@@ -22081,6 +22862,7 @@ components:
         valid:
           type: boolean
           example: true
+    Value: {}
     WebhookDetails:
       type: object
       title: Webhook Details
@@ -22166,6 +22948,7 @@ tags:
   - name: Disputes
   - name: Events
   - name: License Keys
+  - name: Entitlements
   - name: Licenses
   - name: Discounts
   - name: Meters
@@ -23275,6 +24058,7 @@ webhooks:
                 payload_type: LicenseKey
                 payment_id: pay_E5v6dwdKJCg83Gcxd3TRA
                 product_id: pdt_64iOqOi80QypjfohmrwAH
+                source: auto
                 status: active
                 subscription_id: null
               timestamp: '2025-08-04T05:43:19.882409Z'


### PR DESCRIPTION
## Summary

- Adds new `POST /license_keys` API reference page for creating/importing license keys
- Adds `create-license-key` entry to the Licenses navigation group in `docs.json` (English only, no translated files touched)

## Context

The OpenAPI spec already defines the `create_license_key` operation (`POST /license_keys`) with request schema (`CreateLicenseKeyRequest`), response schema (`LicenseKeyResponse`), and SDK code samples. This PR adds the corresponding Mintlify docs page that references it.

Use case: Create and manage your own license keys, or import license keys from another system into Dodo Payments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API reference documentation for the Create License Key endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->