### PR TITLE
docs: add Create License Key API endpoint and update license key docs

### DIFF
--- a/api-reference/licenses/create-license-key.mdx
+++ b/api-reference/licenses/create-license-key.mdx
@@ -4,3 +4,7 @@ description: Create a new license key or import an existing one from another sys
 keywords: ["Dodo Payments", "API reference", "REST API", "create license key", "import license key"]
 openapi: post /license_keys
 ---
+
+<Info>
+License keys created or updated through the API do not trigger email notifications to customers. If you need to notify customers about their license key, you must handle that separately in your application.
+</Info>

--- a/api-reference/licenses/update-license-key.mdx
+++ b/api-reference/licenses/update-license-key.mdx
@@ -4,3 +4,7 @@ description: This endpoint allows you to update a license key by its ID.
 keywords: ["Dodo Payments", "API reference", "REST API", "update license key"]
 openapi: patch /license_keys/{id}
 ---
+
+<Info>
+Updating a license key through the API does not trigger email notifications to the customer.
+</Info>

--- a/features/license-keys.mdx
+++ b/features/license-keys.mdx
@@ -65,6 +65,10 @@ License keys are unique tokens that authorize access to your product. They're id
 
 Already have license keys in another system? Use the [Create License Key](/api-reference/licenses/create-license-key) API to import them into Dodo Payments. This lets you migrate existing keys without disrupting your customers.
 
+<Warning>
+License keys created or updated through the API do not trigger email notifications to customers. If you need to notify customers about their license key, you must handle that separately in your application.
+</Warning>
+
 <CodeGroup>
 ```typescript TypeScript/Node.js
 import DodoPayments from 'dodopayments';


### PR DESCRIPTION
## Summary

- Adds new `POST /license_keys` API reference page for creating/importing license keys
- Updates the license keys feature page with:
  - New **"Import License Keys via API"** section with TypeScript + cURL examples
  - **"Create License Key"** card in the License Key Management API accordion
  - **"Create a license key"** integration example alongside existing activate/validate examples
- Adds disclaimer on `create-license-key` and `update-license-key` API pages that API-created/updated license keys **do not trigger email notifications** to customers
- Navigation updated in `docs.json` (English only, no translated files touched)

## Files Changed

| File | Change |
|---|---|
| `api-reference/licenses/create-license-key.mdx` | New API reference page + email disclaimer |
| `api-reference/licenses/update-license-key.mdx` | Added email disclaimer |
| `features/license-keys.mdx` | Import section, API card, code example, email warning |
| `docs.json` | Added `create-license-key` to Licenses nav group |