### PR TITLE
docs: add disclaimer that API license key operations don't trigger customer emails

### DIFF
--- a/api-reference/licenses/create-license-key.mdx
+++ b/api-reference/licenses/create-license-key.mdx
@@ -4,3 +4,7 @@ description: Create a new license key or import an existing one from another sys
 keywords: ["Dodo Payments", "API reference", "REST API", "create license key", "import license key"]
 openapi: post /license_keys
 ---
+
+<Info>
+License keys created or updated through the API do not trigger email notifications to customers. If you need to notify customers about their license key, you must handle that separately in your application.
+</Info>

--- a/api-reference/licenses/update-license-key.mdx
+++ b/api-reference/licenses/update-license-key.mdx
@@ -4,3 +4,7 @@ description: This endpoint allows you to update a license key by its ID.
 keywords: ["Dodo Payments", "API reference", "REST API", "update license key"]
 openapi: patch /license_keys/{id}
 ---
+
+<Info>
+Updating a license key through the API does not trigger email notifications to the customer.
+</Info>

--- a/features/license-keys.mdx
+++ b/features/license-keys.mdx
@@ -65,6 +65,10 @@ License keys are unique tokens that authorize access to your product. They're id
 
 Already have license keys in another system? Use the [Create License Key](/api-reference/licenses/create-license-key) API to import them into Dodo Payments. This lets you migrate existing keys without disrupting your customers.
 
+<Warning>
+License keys created or updated through the API do not trigger email notifications to customers. If you need to notify customers about their license key, you must handle that separately in your application.
+</Warning>
+
 <CodeGroup>
 ```typescript TypeScript/Node.js
 import DodoPayments from 'dodopayments';


### PR DESCRIPTION
## Summary

- Adds info notices on the **Create License Key** and **Update License Key** API reference pages clarifying that these operations do not send email notifications to customers
- Adds a warning callout in the **Import License Keys via API** section of the license keys feature page with the same disclaimer

## Files Changed

| File | Change |
|---|---|
| `api-reference/licenses/create-license-key.mdx` | `<Info>` disclaimer added |
| `api-reference/licenses/update-license-key.mdx` | `<Info>` disclaimer added |
| `features/license-keys.mdx` | `<Warning>` callout added in the import section |