### PR TITLE
docs: add license key migration support to migrate page

### DIFF
--- a/migrate-to-dodo.mdx
+++ b/migrate-to-dodo.mdx
@@ -2,16 +2,16 @@
 title: "Migrate to Dodo Payments"
 description: "Easily migrate your data from other payment providers to Dodo Payments using our CLI tool"
 icon: "arrow-right-arrow-left"
-keywords: ["Dodo Payments", "migration guide", "payment migration", "switching providers", "migrate to dodo payments"]
+keywords: ["Dodo Payments", "migration guide", "payment migration", "switching providers", "migrate to dodo payments", "license key migration"]
 ---
 
-**Switching from another payment provider to Dodo Payments?** Our migration tool makes it easy to move your **products, customers, and discount codes without losing any data.** The process is safe, guided, and can be done in just a few minutes.
+**Switching from another payment provider to Dodo Payments?** Our migration tool makes it easy to move your **products, customers, discount codes, and license keys without losing any data.** The process is safe, guided, and can be done in just a few minutes.
 
 We currently support migrations from **Lemon Squeezy, Stripe, Polar.sh, and Paddle**.
 
 ### Supported Migrations
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Products & Pricing" icon="box">
     Migrate all your products and pricing details.
   </Card>
@@ -20,6 +20,9 @@ We currently support migrations from **Lemon Squeezy, Stripe, Polar.sh, and Padd
   </Card>
   <Card title="Discount Codes & Promotions" icon="tag">
     Move all discount codes and promotional offers seamlessly.
+  </Card>
+  <Card title="License Keys" icon="key">
+    Import license keys with customer and product mappings. Supported for Polar.sh and Lemon Squeezy.
   </Card>
 </CardGroup>
 
@@ -66,6 +69,7 @@ The tool will walk you through everything step by step. You'll need:
 - Your Dodo Payments API key  
 - Whether you want to test first (recommended) or go live
 - Which Dodo Payments brand to migrate to
+- What data to migrate (products, customers, discounts, license keys)
 
 ## Why Use Our Migration Tool?
 
@@ -107,7 +111,7 @@ dodo-migrate polar \
   --dodo-api-key=dp_XXXXXXXXXXXXXXXX \
   --mode=test_mode \
   --dodo-brand-id=brand_XXXXXX \
-  --migrate-types=products,discounts,customers
+  --migrate-types=products,discounts,customers,license_keys
 ```
 
 ### Paddle migration:
@@ -119,6 +123,31 @@ dodo-migrate paddle \
   --mode=test_mode \
   --dodo-brand-id=brand_XXXXXX
 ```
+
+## License Key Migration
+
+License key migration is supported for **Polar.sh** and **Lemon Squeezy**. When you select license keys in the interactive prompt (or pass `license_keys` in `--migrate-types`), the tool will import your existing license keys into Dodo Payments with the correct customer and product associations.
+
+<Warning>
+License key migration requires **products and customers** to be migrated in the same session. The tool builds an in-memory mapping of provider IDs to Dodo IDs during the run — if products or customers are missing, license keys cannot be linked correctly.
+</Warning>
+
+### What gets migrated
+
+- License key strings
+- Activation limits
+- Expiration dates
+- Customer and product associations
+
+### What doesn't migrate
+
+- **License key activations** — customers will need to re-activate on their devices after migration
+- **Revoked or disabled keys** — only active keys are migrated
+- Keys without a matching product or customer are skipped with a warning
+
+<Tip>
+Duplicate license keys are handled gracefully. If you re-run the migration, already-imported keys are detected and skipped, making the process safe to retry.
+</Tip>
 
 ## Need Help?
 


### PR DESCRIPTION
## Summary

- Adds license key migration documentation to the "Migrate to Dodo Payments" page, reflecting the new functionality added in [dodopayments/dodo-migrate#41](https://github.com/dodopayments/dodo-migrate/pull/41)
- Adds a **License Keys** card to the supported migrations section
- Adds a dedicated **License Key Migration** section covering what migrates, what doesn't, and the requirement that products + customers must be in the same session
- Updates the Polar.sh non-interactive example to include `license_keys` in `--migrate-types`
- Only the English source file is modified — translated files are untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide to include license key migration support
  * Added details on migrating license keys from Polar.sh/Lemon Squeezy
  * Expanded migration checklist to include license key selection
  * Updated CLI examples to support license key migration parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->