### PR TITLE
docs(customer-portal): document 21-language localization support

### DIFF
--- a/features/customer-portal.mdx
+++ b/features/customer-portal.mdx
@@ -43,6 +43,7 @@ The portal provides a trusted, branded self‑service experience for customers t
 - **Faster time‑to‑value**: Immediate access to invoices and keys
 - **Reduced churn risk**: Clear visibility into renewals and plan details
 - **Secure by design**: Tokenized access with expiring links
+- **Localized experience**: Portal is available in 21 languages, with automatic detection based on the customer's browser preferences
 
 ## Access Methods
 
@@ -150,6 +151,37 @@ Scroll down to view saved payment methods and a complete billing history with st
 <Frame>
     <img src="/images/customer-portal/payment-methods-invoices.png" alt="Payment methods and billing history with invoice downloads" style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
+
+## Language Support
+
+The Customer Portal is available in **21 languages**, so your customers can manage their subscriptions, payment methods, and billing history in the language they're most comfortable with.
+
+### How language selection works
+
+- **Automatic detection**: On first visit, the portal detects the customer's preferred language from their browser settings and loads the matching translation if available. English is used as the fallback.
+- **Manual override**: Customers can change the active language at any time from the language selector in the portal header (available on both desktop and mobile).
+- **Persisted preference**: The selected language is stored in the `NEXT_LOCALE` cookie (valid for 1 year) so the portal remembers the choice across sessions.
+- **Embedded contexts**: When the portal is embedded in an iframe and cookies are blocked, the portal falls back to a `forceLanguage` URL parameter so the chosen language is still respected.
+
+### Supported languages
+
+| Language | Code | Language | Code |
+|----------|------|----------|------|
+| English (default) | `en` | Indonesian | `id` |
+| Arabic | `ar` | Italian | `it` |
+| Catalan | `ca` | Japanese | `ja` |
+| Chinese | `zh` | Korean | `ko` |
+| Dutch | `nl` | Malay | `ms` |
+| French | `fr` | Polish | `pl` |
+| German | `de` | Portuguese | `pt` |
+| Hebrew | `he` | Romanian | `ro` |
+| Russian | `ru` | Spanish | `es` |
+| Swedish | `sv` | Thai | `th` |
+| Turkish | `tr` |   |   |
+
+<Info>
+The Customer Portal renders from right-to-left (RTL) automatically for languages that require it, such as Arabic and Hebrew.
+</Info>
 
 ## Plan Changes (Upgrade/Downgrade)
 


### PR DESCRIPTION
## Summary

- Document that the Customer Portal now supports 21 localized languages (added in `dodo-customer-portal`, commits `e193eeb`/`f41b587`).
- Explain language detection, manual selector, cookie persistence, iframe `forceLanguage` fallback, and automatic RTL rendering.
- Add a supported-languages reference table and a matching bullet under **Key Benefits**.

## Source of truth

Language set confirmed from `dodo-customer-portal/src/i18n/config.ts`:

> en, ar, ca, zh, de, es, fr, he, id, it, ja, ko, ms, nl, pl, pt, ro, ru, sv, th, tr (21 languages total)

Selector/persistence behavior confirmed from `src/components/custom/language-selector.tsx` (browser detection, `NEXT_LOCALE` cookie, iframe `forceLanguage` URL param).

## Scope

- Only the English source page `features/customer-portal.mdx` is updated.
- Translated copies under `ar/`, `cn/`, `de/`, `es/`, `fr/`, `hi/`, `id/`, `it/`, `ja/`, `ko/`, `pt-BR/`, `sv/`, `vi/` are intentionally left untouched; Lingo will regenerate them on the next translation run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Language Support section to Customer Portal documentation
  * Documented support for 21 languages with automatic browser-based detection and manual override options
  * Added language preference persistence and fallback mechanisms
  * Extended key benefits with localized experience offering
  * Included RTL (right-to-left) rendering support documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->