### PR TITLE
docs(intro): add For Humans / For AI Agents sections and rename navbar tab to Docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -39,7 +39,7 @@
         "language": "en",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -811,7 +811,7 @@
         "language": "es",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -1562,7 +1562,7 @@
         "language": "ar",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -2312,7 +2312,7 @@
         "language": "fr",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -3065,7 +3065,7 @@
         "language": "de",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -3815,7 +3815,7 @@
         "language": "id",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -4566,7 +4566,7 @@
         "language": "ja",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -5320,7 +5320,7 @@
         "language": "ko",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -6071,7 +6071,7 @@
         "language": "pt-BR",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -6824,7 +6824,7 @@
         "language": "vi",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -7576,7 +7576,7 @@
         "language": "cn",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -8327,7 +8327,7 @@
         "language": "hi",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -9079,7 +9079,7 @@
         "language": "it",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {
@@ -9829,7 +9829,7 @@
         "language": "sv",
         "tabs": [
           {
-            "tab": "Documentation",
+            "tab": "Docs",
             "icon": "book",
             "groups": [
               {

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -54,9 +54,13 @@ Dodo Payments is the **all-in-one engine** to launch, scale, and monetize worldw
 </Card>
 </CardGroup>
 
+## Quick Start Guide
+
+Get up and running with Dodo Payments in just a few steps.
+
 <AccordionGroup>
 <Accordion title="For Humans">
-  Prefer to drive the integration yourself? The **[Quick Start](#quick-start-guide)** below walks you through creating an account, adding a product, and picking an integration method in under five minutes. No code required for the no-code path; SDK samples are waiting in every major language if you want them.
+  Prefer to drive the integration yourself? The steps below walk you through creating an account, adding a product, and picking an integration method in under five minutes. No code required for the no-code path; SDK samples are waiting in every major language if you want them.
 
   If you'd rather let your AI coding assistant do the heavy lifting - integration scaffolding, webhook handlers, subscription flows - install **[Sentra](/developer-resources/sentra)**, our AI billing assistant for VS Code, Cursor, and Windsurf. Describe what you want; Sentra plans, scaffolds, and ships it.
 </Accordion>
@@ -82,10 +86,6 @@ Dodo Payments is the **all-in-one engine** to launch, scale, and monetize worldw
   Works with Claude Code, OpenCode, Cursor, and any MCP-compatible agent.
 </Accordion>
 </AccordionGroup>
-
-## Quick Start Guide
-
-Get up and running with Dodo Payments in just a few steps:
 
 <Steps>
 <Step title="Create Your Account">

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -54,6 +54,33 @@ Dodo Payments is the **all-in-one engine** to launch, scale, and monetize worldw
 </Card>
 </CardGroup>
 
+### For Humans
+
+Prefer to drive the integration yourself? The **[Quick Start](#quick-start-guide)** below walks you through creating an account, adding a product, and picking an integration method in under five minutes. No code required for the no-code path; SDK samples are waiting in every major language if you want them.
+
+If you'd rather let your AI coding assistant do the heavy lifting - integration scaffolding, webhook handlers, subscription flows - install **[Sentra](/developer-resources/sentra)**, our AI billing assistant for VS Code, Cursor, and Windsurf. Describe what you want; Sentra plans, scaffolds, and ships it.
+
+### For AI Agents
+
+Dodo Payments is built for agent-native workflows. If you're an LLM reading this - or a developer configuring one - start here.
+
+**Discover**. The full docs index is served at [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt), and every documentation page is available in plain markdown by appending `.md` to its URL (e.g. `/api-reference/introduction.md`).
+
+**Connect**. Two MCP servers give agents live access to the platform:
+
+- **[Dodo Knowledge MCP](/developer-resources/mcp-server#dodo-knowledge-mcp)** - semantic search across all Dodo documentation
+- **[Dodo Payments MCP](/developer-resources/mcp-server)** - execute API operations (create payments, manage subscriptions, issue refunds)
+
+See the [MCP Server guide](/developer-resources/mcp-server) for the full client configuration.
+
+**Extend**. Install official [Dodo Payments Skills](/developer-resources/agent-skills) to teach your agent how to handle checkout, subscriptions, usage-based billing, credit-based billing, webhooks, and more:
+
+```bash
+npx skills add dodopayments/skills
+```
+
+Works with Claude Code, OpenCode, Cursor, and any MCP-compatible agent.
+
 ## Quick Start Guide
 
 Get up and running with Dodo Payments in just a few steps:

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -54,32 +54,34 @@ Dodo Payments is the **all-in-one engine** to launch, scale, and monetize worldw
 </Card>
 </CardGroup>
 
-### For Humans
+<AccordionGroup>
+<Accordion title="For Humans">
+  Prefer to drive the integration yourself? The **[Quick Start](#quick-start-guide)** below walks you through creating an account, adding a product, and picking an integration method in under five minutes. No code required for the no-code path; SDK samples are waiting in every major language if you want them.
 
-Prefer to drive the integration yourself? The **[Quick Start](#quick-start-guide)** below walks you through creating an account, adding a product, and picking an integration method in under five minutes. No code required for the no-code path; SDK samples are waiting in every major language if you want them.
+  If you'd rather let your AI coding assistant do the heavy lifting - integration scaffolding, webhook handlers, subscription flows - install **[Sentra](/developer-resources/sentra)**, our AI billing assistant for VS Code, Cursor, and Windsurf. Describe what you want; Sentra plans, scaffolds, and ships it.
+</Accordion>
 
-If you'd rather let your AI coding assistant do the heavy lifting - integration scaffolding, webhook handlers, subscription flows - install **[Sentra](/developer-resources/sentra)**, our AI billing assistant for VS Code, Cursor, and Windsurf. Describe what you want; Sentra plans, scaffolds, and ships it.
+<Accordion title="For AI Agents">
+  Dodo Payments is built for agent-native workflows. If you're an LLM reading this - or a developer configuring one - start here.
 
-### For AI Agents
+  **Discover**. The full docs index is served at [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt), and every documentation page is available in plain markdown by appending `.md` to its URL (e.g. `/api-reference/introduction.md`).
 
-Dodo Payments is built for agent-native workflows. If you're an LLM reading this - or a developer configuring one - start here.
+  **Connect**. Two MCP servers give agents live access to the platform:
 
-**Discover**. The full docs index is served at [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt), and every documentation page is available in plain markdown by appending `.md` to its URL (e.g. `/api-reference/introduction.md`).
+  - **[Dodo Knowledge MCP](/developer-resources/mcp-server#dodo-knowledge-mcp)** - semantic search across all Dodo documentation
+  - **[Dodo Payments MCP](/developer-resources/mcp-server)** - execute API operations (create payments, manage subscriptions, issue refunds)
 
-**Connect**. Two MCP servers give agents live access to the platform:
+  See the [MCP Server guide](/developer-resources/mcp-server) for the full client configuration.
 
-- **[Dodo Knowledge MCP](/developer-resources/mcp-server#dodo-knowledge-mcp)** - semantic search across all Dodo documentation
-- **[Dodo Payments MCP](/developer-resources/mcp-server)** - execute API operations (create payments, manage subscriptions, issue refunds)
+  **Extend**. Install official [Dodo Payments Skills](/developer-resources/agent-skills) to teach your agent how to handle checkout, subscriptions, usage-based billing, credit-based billing, webhooks, and more:
 
-See the [MCP Server guide](/developer-resources/mcp-server) for the full client configuration.
+  ```bash
+  npx skills add dodopayments/skills
+  ```
 
-**Extend**. Install official [Dodo Payments Skills](/developer-resources/agent-skills) to teach your agent how to handle checkout, subscriptions, usage-based billing, credit-based billing, webhooks, and more:
-
-```bash
-npx skills add dodopayments/skills
-```
-
-Works with Claude Code, OpenCode, Cursor, and any MCP-compatible agent.
+  Works with Claude Code, OpenCode, Cursor, and any MCP-compatible agent.
+</Accordion>
+</AccordionGroup>
 
 ## Quick Start Guide
 


### PR DESCRIPTION
## Summary

- **Add a dual-path onboarding chooser** at the top of the Quick Start Guide on `introduction.mdx`. Two collapsed accordions — **For Humans** and **For AI Agents** — let each audience jump to their paved path without forcing the other to scroll past a wall of content.
- **Rename the navbar tab** from `Documentation` to `Docs` across all 14 locale blocks in `docs.json` for a tighter global nav.

## Placement

The accordions sit right under the `## Quick Start Guide` heading, above the existing `<Steps>` block. The "Why Choose Dodo Payments?" card grid now flows directly into the Quick Start heading with no intermediate content.

```
Why Choose Dodo Payments? (cards)
↓
## Quick Start Guide
   Get up and running with Dodo Payments in just a few steps.
   ▸ For Humans                  ← collapsed accordion
   ▸ For AI Agents               ← collapsed accordion
   <Steps> … </Steps>            ← existing 3-step guide
```

## Design journey (captured in commits)

1. **Initial version** shipped both sections as open H3 prose blocks above the Quick Start Guide. When rendered, they filled ~800px of viewport between "Why Choose" and the Steps — forcing every human reader to scroll past mostly agent-facing content.
2. **First fix** wrapped both sections in a collapsed `<AccordionGroup>` to cut the footprint to ~60px while keeping labels discoverable.
3. **Current placement** moves the accordion group inside the Quick Start Guide section, right where audience-specific guidance belongs — a reader landing there is ready to start, so "For Humans / For AI Agents" is a natural fork before the steps.

Agents still receive the full content via `llms.txt` and the auto-served `.md` version of the intro page, so agent discoverability is preserved regardless of the visual collapse.

## What the accordions contain

**For Humans** — pitches the steps that follow below, plus [Sentra](https://docs.dodopayments.com/developer-resources/sentra) as the "let my AI IDE assistant do it" alternative.

**For AI Agents** — three-part agent onboarding that surfaces assets Dodo already ships:
- **Discover**: [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt) + Mintlify's auto-served `.md` endpoints on every page.
- **Connect**: Dodo Knowledge MCP (semantic docs search) and Dodo Payments MCP (live API operations).
- **Extend**: `npx skills add dodopayments/skills` with the list of capabilities skills teach.

The accordions deliberately **link to canonical pages** rather than duplicate content. The full MCP JSON config and skills setup block that already appear further down the same page are untouched.

## Design decisions (and what was deliberately left out)

Benchmarked across Stripe, Anthropic, Vercel, Cloudflare, Supabase, Mintlify, Paddle, Polar:

- **Included** (2026 table stakes): llms.txt surfacing, dual-MCP framing, markdown access, Skills.
- **Not included in this PR** (recommended as follow-ups):
  - Multi-framework agent code examples (OpenAI SDK / LangChain / CrewAI / Vercel AI) — belongs on a dedicated \`/developer-resources/ai-agents\` page.
  - Security / prompt-injection guidance — belongs on the MCP server page.
  - Sandbox-vs-production MCP URLs (Polar pattern).
  - Copy-paste prompt templates.
  - AGENTS.md at repo root.
  - Localisation of the new sections into the 13 non-English locales.

## Scope / what is NOT touched

- **No translated \`.mdx\` files were modified.** The \`ar/\`, \`cn/\`, \`de/\`, \`es/\`, \`fr/\`, \`hi/\`, \`id/\`, \`it/\`, \`ja/\`, \`ko/\`, \`pt-BR/\`, \`sv/\`, \`vi/\` directories are untouched, per the original request.
- The navbar rename in \`docs.json\` affects all 14 locale blocks because each block currently holds the literal English string \`\"Documentation\"\` (not a localised translation). Changing only the English block would have left 13 locales saying \"Documentation\" while English said \"Docs\" — a broken UX. Since \`docs.json\` is config, not translated content, it's in scope.

## Verification

- \`docs.json\` parses cleanly (validated with \`python3 -m json.tool\`).
- All 14 \`\"tab\"\` entries now say \`\"Docs\"\`; zero \`\"Documentation\"\` remain.
- \`## Quick Start Guide\` heading preserved — the only self-reference inside the accordions (\"The Quick Start below…\") was rewritten to \"The steps below…\" now that the accordion sits inside the section.
- All 3 linked target files exist: \`developer-resources/sentra.mdx\`, \`developer-resources/mcp-server.mdx\`, \`developer-resources/agent-skills.mdx\`.
- \`#dodo-knowledge-mcp\` anchor confirmed to exist in \`developer-resources/mcp-server.mdx\`.
- \`docs.dodopayments.com/llms.txt\` returns HTTP 200 with the full docs index.
- \`<AccordionGroup>\` / \`<Accordion>\` component syntax matches existing usage on the same page (Framework Adapters, Communication & Notifications).

## Files changed

- \`introduction.mdx\` — Quick Start Guide now opens with a dual-path AccordionGroup
- \`docs.json\` — 14 tab-label replacements

## Commits

1. \`docs(intro): add For Humans / For AI Agents sections and rename navbar tab to Docs\` — initial H3 implementation + navbar rename.
2. \`docs(intro): collapse dual-path sections into an AccordionGroup\` — UX fix after seeing the rendered output.
3. \`docs(intro): relocate dual-path accordions inside Quick Start Guide\` — move accordions under the Quick Start heading where the audience fork belongs.