### PR TITLE
fix: update docs appearance colors, content width, and mintignore

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,1 +1,3 @@
 .sisyphus/
+.github/
+node_modules/

--- a/docs.json
+++ b/docs.json
@@ -2,10 +2,10 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "Dodo Payments Documentation",
-  "colors": {
-    "primary": "#81B700",
+"colors": {
+    "primary": "#779812",
     "light": "#C6FE1E",
-    "dark": "#81B700"
+    "dark": "#166534"
   },
   "fonts": {
     "heading": {

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
+#content-area {
+  max-width: 60rem;
+}
+
+
+
 .welcome-page .card-group {
   margin: 3rem auto 8rem;
   max-width: 70rem;


### PR DESCRIPTION
## Summary

- **Brand colors**: Updated to `#779812` (light mode), `#C6FE1E` (dark mode emphasis), `#166534` (buttons/hover) for better contrast in both modes
- **Content width**: Widened from default `48rem` to `60rem` via `#content-area` CSS override
- **Mintignore**: Added `.github/` and `node_modules/` to fix MDX parsing errors from non-docs files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the primary and dark theme color palette to enhance visual consistency and improve overall interface appearance
  * Constrained maximum width of the content area for better visual hierarchy and improved readability

* **Chores**
  * Updated build ignore configuration to exclude additional directories from processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->