### PR TITLE
fix: add letter-spacing to ApfelGrotezk headings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 }
 
 h1, h2, h3, h4, h5, h6 {
-  letter-spacing: 0.06em !important;
+  letter-spacing: 0.05em !important;
 }
 
 .welcome-page .card-group {

--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,9 @@
   max-width: 60rem;
 }
 
-
+h1, h2, h3, h4, h5, h6 {
+  letter-spacing: 0.01em;
+}
 
 .welcome-page .card-group {
   margin: 3rem auto 8rem;

--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
 }
 
 h1, h2, h3, h4, h5, h6 {
-  letter-spacing: 0.01em;
+  letter-spacing: 0.06em !important;
 }
 
 .welcome-page .card-group {


### PR DESCRIPTION
## Summary

- Add `letter-spacing: 0.01em` to `h1`–`h6` to fix tight character spacing in ApfelGrotezk headings