### PR TITLE
Add grandfathering clause for accepted countries in Merchant Acceptance Policy

### DIFF
--- a/miscellaneous/merchant-acceptance.mdx
+++ b/miscellaneous/merchant-acceptance.mdx
@@ -309,6 +309,10 @@ If your product operates near the edge of these categories, we encourage you to 
 </Accordion>
 </AccordionGroup>
 
+<Note>
+This policy applies to all country designations made on or after March 23, 2026. Merchants receiving services in countries supported prior to this date will not be affected, unless the relevant country is subject to active sanctions or regulatory restrictions. In such cases, Dodo Payments reserves the right to discontinue support.
+</Note>
+
 ## Accepted Territories
 
 <AccordionGroup>


### PR DESCRIPTION
## Summary

- Adds a grandfathering clause under the **Accepted Countries** section of the Merchant Acceptance Policy
- The clause clarifies that the policy applies to country designations made on or after **March 23, 2026**, and that existing merchants are unaffected unless the country is subject to active sanctions or regulatory restrictions
- Only the English source file is modified — translated files are untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on merchant acceptance policy effective March 23, 2026. The policy applies to new country designations from that date forward. Existing merchants remain unaffected unless they operate in sanctioned or regulatory-restricted countries, where service may be discontinued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->