### PR TITLE
docs: add Build with AI Coding Agents page and surface Agent Plugin

### DIFF
--- a/developer-resources/agent-skills.mdx
+++ b/developer-resources/agent-skills.mdx
@@ -37,6 +37,12 @@ Skills work with any MCP-compatible AI agent, including:
 Choose your preferred installation method based on your AI coding assistant.
 
 <Tabs>
+<Tab title="Agent Plugin (recommended)">
+If you're using Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs all eight skills plus both MCP servers in one step. Skills load automatically when your agent detects a relevant task.
+
+See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+</Tab>
+
 <Tab title="Skills CLI">
 Install skills using the universal skills CLI that works with any MCP-compatible agent:
 

--- a/developer-resources/build-with-ai-coding-agents.mdx
+++ b/developer-resources/build-with-ai-coding-agents.mdx
@@ -1,0 +1,241 @@
+---
+title: "Build with AI Coding Agents"
+sidebarTitle: "AI Coding Agents"
+description: "Use the Dodo Agent Plugin to build integrations with Claude Code, Codex CLI, Cursor, and OpenCode — MCP servers and skills in one install."
+icon: "robot"
+keywords: ["Dodo Payments", "AI agent", "Claude Code", "Codex CLI", "Cursor", "OpenCode", "MCP", "coding agent", "agent plugin"]
+---
+
+The Dodo Agent Plugin wires two MCP servers and eight integration skills into your AI coding agent in a single install. It works with **Claude Code**, **Codex CLI**, **Cursor**, and **OpenCode** — and the MCP servers and skills CLI work with any MCP-compatible client.
+
+<Info>
+**Three primitives, one plugin.** The Agent Plugin bundles everything you need:
+- **API MCP server** — live access to payments, subscriptions, customers, products, refunds, licenses, and usage. Authenticates via browser OAuth (no local keys required).
+- **Knowledge MCP server** — semantic search across all Dodo Payments documentation. No credentials needed.
+- **Eight agent skills** — cheat sheets your agent loads on demand for checkout, subscriptions, webhooks, usage-based billing, credit-based billing, license keys, BillingSDK, and best practices.
+</Info>
+
+## Install the plugin
+
+Choose your coding agent below. The install adds both MCP servers and all eight skills automatically.
+
+<AccordionGroup>
+<Accordion title="Claude Code" defaultOpen>
+Install from the marketplace:
+
+```bash
+claude plugins marketplace add dodopayments/dodo-agent-plugin
+claude plugins install dodopayments@dodopayments
+```
+
+The API MCP server uses browser OAuth by default — no keys required at install time. The first time your agent calls a Dodo tool, you'll be prompted to sign in.
+
+<Card title="Dodo Agent Plugin on GitHub" icon="github" href="https://github.com/dodopayments/dodo-agent-plugin">
+  Source code, configuration options, and local development instructions
+</Card>
+</Accordion>
+
+<Accordion title="Codex CLI">
+Codex reads `.claude-plugin/marketplace.json` natively, so the same plugin repo works:
+
+```bash
+codex plugin marketplace add dodopayments/dodo-agent-plugin
+codex plugin install dodopayments@dodopayments
+```
+
+Both MCP servers and all eight skills are registered automatically.
+</Accordion>
+
+<Accordion title="Cursor">
+Manual install — clone the repo into Cursor's local plugins directory:
+
+```bash
+git clone https://github.com/dodopayments/dodo-agent-plugin.git ~/.cursor/plugins/local/dodo-agent-plugin
+```
+
+Restart Cursor. The plugin loads skills from `.claude/skills/` (via Cursor's Claude Code compatibility layer) and MCP servers from `.mcp.json`.
+
+<Info>
+Cursor marketplace support is coming. For now, use the manual install above.
+</Info>
+</Accordion>
+
+<Accordion title="OpenCode">
+OpenCode distributes via npm. Add the plugin to your `opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@dodopayments/opencode-plugin"]
+}
+```
+
+Restart OpenCode. Both MCP servers (`dodopayments-api`, `dodo-knowledge`) are registered automatically via the plugin's config hook, and the eight skills are auto-discovered from the installed package. No manual `mcp` block required.
+</Accordion>
+</AccordionGroup>
+
+<Info>
+Using a different agent? The [MCP Server](/developer-resources/mcp-server) and [Agent Skills](/developer-resources/agent-skills) guides cover Cursor, Claude Desktop, VS Code, Windsurf, Cline, Zed, and any MCP-compatible client.
+</Info>
+
+## What you get
+
+Once the plugin is installed, your agent has access to two MCP servers and eight skills.
+
+### MCP servers
+
+| Server | Purpose | Auth |
+|--------|---------|------|
+| `dodopayments-api` | Live API access — payments, subscriptions, customers, products, refunds, licenses, usage | OAuth (browser) |
+| `dodo-knowledge` | Semantic search across all Dodo Payments documentation | None |
+
+Both servers are wired through `mcp-remote` so they run in any MCP-compatible client.
+
+### Agent skills
+
+| Skill | Description |
+|-------|-------------|
+| `best-practices` | Comprehensive guide to integrating Dodo Payments with best practices |
+| `checkout-integration` | Creating checkout sessions and payment flows |
+| `subscription-integration` | Implementing subscription billing flows |
+| `webhook-integration` | Setting up and handling webhooks for payment events |
+| `usage-based-billing` | Implementing metered billing with events and meters |
+| `credit-based-billing` | Credit entitlements, balances, and metered credit deduction |
+| `license-keys` | Managing license keys for digital products |
+| `billing-sdk` | Using BillingSDK React components |
+
+Skills load automatically — your agent picks the right one when it detects a relevant task. See the [Agent Skills documentation](/developer-resources/agent-skills) for the full list and individual installation.
+
+### Try this prompt first
+
+Once the plugin is active, try:
+
+```
+Set up Dodo Payments webhook handlers in my Next.js app for payment.succeeded and subscription.active events.
+```
+
+Your agent will load the `webhook-integration` skill, use the `dodo-knowledge` MCP to pull the latest payload shapes, and write a handler with signature verification following the Standard Webhooks spec.
+
+## Other supported agents
+
+The Agent Plugin covers Claude Code, Codex CLI, Cursor, and OpenCode. If you use a different agent, connect to Dodo Payments through the MCP servers and skills CLI:
+
+| Agent | Fastest path | Also supports |
+|-------|-------------|---------------|
+| **Claude Code** | Agent Plugin (one command) | MCP server, individual skills |
+| **Codex CLI** | Agent Plugin (one command) | MCP server |
+| **Cursor** | Agent Plugin (git clone) | MCP server config, skills CLI |
+| **OpenCode** | Agent Plugin (npm) | MCP server config, skills CLI |
+| GitHub Copilot (VS Code) | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
+| Claude Desktop | [MCP Server guide](/developer-resources/mcp-server) | — |
+| Windsurf | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
+| Cline / Zed / others | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
+
+## Docs built for agents
+
+Every Dodo Payments documentation page is available in a format optimized for AI consumption:
+
+- **Full docs index**: [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt) — serves the complete documentation index for context ingestion.
+- **Plain markdown**: Append `.md` to any documentation URL to get the raw markdown version (e.g., `/api-reference/introduction.md`).
+- **Source repository**: [`github.com/dodopayments/dodo-docs`](https://github.com/dodopayments/dodo-docs) — clone for offline indexing.
+
+## What your agent can do
+
+With the plugin installed, your coding agent can:
+
+- **Create checkout sessions and payment links** — [One-time payments](/features/one-time-payment-products) and [subscriptions](/features/subscription)
+- **Stand up subscription and usage-based billing end-to-end** — [Subscriptions](/features/subscription), [Usage-based billing](/features/usage-based-billing), [Credit-based billing](/features/credit-based-billing)
+- **Generate Standard Webhooks–compliant handlers** with signature verification — [Webhooks](/developer-resources/webhooks)
+- **Wire BillingSDK React components** for pricing tables and subscription management — [BillingSDK](/developer-resources/billingsdk)
+- **Author license-key flows** for digital products — [License keys](/features/license-keys)
+- **Implement credit-based billing** with entitlements, balances, rollover, and overage — [Credits](/features/credit-based-billing)
+
+## Security and best practices
+
+<Warning>
+**Never commit production API keys.** Use [test mode](/miscellaneous/test-mode-vs-live-mode) during development. The Agent Plugin uses browser OAuth by default — only switch to local API keys if your workflow requires it.
+</Warning>
+
+- **Use test mode first.** Sandbox your integration with `dodo_test_...` keys before going live. See [Test Mode vs Live Mode](/miscellaneous/test-mode-vs-live-mode).
+- **OAuth is the default.** The Agent Plugin authenticates via browser OAuth (no local secrets). Only use API-key mode if you need it — see the Configure section below.
+- **Review agent-generated code.** Always verify webhook handlers include signature verification following the [Standard Webhooks spec](https://standardwebhooks.com/).
+
+## Configure with an API key
+
+By default, the Agent Plugin uses the remote MCP server with browser OAuth — no local credentials needed. If your workflow requires a local API key (e.g., CI environments, headless servers), you can switch to stdio mode.
+
+<AccordionGroup>
+<Accordion title="Local API key mode — Claude Code">
+Open `/plugins` in Claude Code, select **Dodo Payments**, and choose **Configure options**. Fill in:
+
+- `dodo_api_key` — your `dodo_test_...` or `dodo_live_...` key
+- `dodo_webhook_key` — your webhook signing secret
+- `dodo_environment` — `test_mode` or `live_mode`
+
+Then edit `.mcp.json` to point `dodopayments-api` at the local stdio server:
+
+```json
+{
+  "mcpServers": {
+    "dodopayments-api": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "dodopayments-mcp@latest"],
+      "env": {
+        "DODO_PAYMENTS_API_KEY": "${user_config.dodo_api_key}",
+        "DODO_PAYMENTS_WEBHOOK_KEY": "${user_config.dodo_webhook_key}",
+        "DODO_PAYMENTS_ENVIRONMENT": "${user_config.dodo_environment}"
+      }
+    }
+  }
+}
+```
+
+Run `/reload-plugins` to apply changes to your current session.
+</Accordion>
+
+<Accordion title="Local API key mode — OpenCode">
+Declare `dodopayments-api` yourself in `opencode.json` — your entry wins over the plugin's default remote server:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@dodopayments/opencode-plugin"],
+  "mcp": {
+    "dodopayments-api": {
+      "type": "local",
+      "command": ["npx", "-y", "dodopayments-mcp@latest"],
+      "environment": {
+        "DODO_PAYMENTS_API_KEY": "dodo_test_...",
+        "DODO_PAYMENTS_WEBHOOK_KEY": "whsec_...",
+        "DODO_PAYMENTS_ENVIRONMENT": "test_mode"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart OpenCode to apply.
+</Accordion>
+</AccordionGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="MCP Server" icon="terminal" href="/developer-resources/mcp-server">
+  Full reference for both MCP servers — all supported clients, configuration, and available tools
+</Card>
+
+<Card title="Agent Skills" icon="wand-magic-sparkles" href="/developer-resources/agent-skills">
+  Individual skill installation, skill reference, and per-agent setup instructions
+</Card>
+
+<Card title="Sentra IDE Assistant" icon="bolt" href="/developer-resources/sentra">
+  AI-powered billing assistant for VS Code, Cursor, and Windsurf — ask, build, and plan in your editor
+</Card>
+
+<Card title="API Reference" icon="book" href="/api-reference/introduction">
+  Complete OpenAPI reference for all Dodo Payments endpoints
+</Card>
+</CardGroup>

--- a/developer-resources/mcp-server.mdx
+++ b/developer-resources/mcp-server.mdx
@@ -38,6 +38,12 @@ Using Code Mode, agents can chain multiple API calls, handle conditional logic, 
 Connect to the Dodo Payments MCP Server in your AI client:
 
 <Tabs>
+<Tab title="Agent Plugin (recommended)">
+The [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs both MCP servers and all eight skills in one step for Claude Code, Codex CLI, Cursor, and OpenCode. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+
+If your agent isn't in that list, use the tabs below to configure the MCP server directly.
+</Tab>
+
 <Tab title="Cursor">
 Add to `~/.cursor/mcp.json`:
 

--- a/docs.json
+++ b/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "Dodo Payments Documentation",
-"colors": {
+  "colors": {
     "primary": "#779812",
     "light": "#C6FE1E",
     "dark": "#166534"
@@ -46,6 +46,7 @@
                 "group": "Getting Started",
                 "pages": [
                   "introduction",
+                  "developer-resources/build-with-ai-coding-agents",
                   "migrate-to-dodo",
                   "miscellaneous/verification-process"
                 ]
@@ -276,10 +277,9 @@
                   "developer-resources/inline-checkout",
                   "developer-resources/sentra",
                   "developer-resources/billingsdk",
-"developer-resources/mcp-server",
-"developer-resources/agent-skills",
-"developer-resources/build-with-ai-coding-agents",
-"developer-resources/dodo-sync",
+                  "developer-resources/mcp-server",
+                  "developer-resources/agent-skills",
+                  "developer-resources/dodo-sync",
                   "miscellaneous/subscription-migration"
                 ]
               },

--- a/docs.json
+++ b/docs.json
@@ -276,9 +276,10 @@
                   "developer-resources/inline-checkout",
                   "developer-resources/sentra",
                   "developer-resources/billingsdk",
-                  "developer-resources/mcp-server",
-                  "developer-resources/agent-skills",
-                  "developer-resources/dodo-sync",
+"developer-resources/mcp-server",
+"developer-resources/agent-skills",
+"developer-resources/build-with-ai-coding-agents",
+"developer-resources/dodo-sync",
                   "miscellaneous/subscription-migration"
                 ]
               },

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -68,6 +68,8 @@ Get up and running with Dodo Payments in just a few steps.
 <Accordion title="For AI Agents">
   Dodo Payments is built for agent-native workflows. If you're an LLM reading this - or a developer configuring one - start here.
 
+  **Install**. For Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) wires both MCP servers and all skills in one step. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+
   **Discover**. The full docs index is served at [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt), and every documentation page is available in plain markdown by appending `.md` to its URL (e.g. `/api-reference/introduction.md`).
 
   **Connect**. Two MCP servers give agents live access to the platform:
@@ -198,11 +200,15 @@ Get up and running with Dodo Payments in just a few steps.
   **Build billing integrations by describing what you need.** Sentra is an AI agent for VS Code, Cursor, and Windsurf that generates SDK code, webhook handlers, subscription flows, and more. Use **Ask** mode to learn, **Build** mode to implement, or **Plan** mode to architect your billing system.
 </Card>
 
-### MCP Servers for AI Assistants
+### Build with AI Coding Agents
 
-Connect your AI coding assistant (Cursor, Claude Desktop, Windsurf, VS Code) directly to Dodo Payments with our MCP servers.
+Connect your AI coding assistant (Claude Code, Codex CLI, Cursor, OpenCode, Windsurf, VS Code) directly to Dodo Payments — install the Agent Plugin for a one-command setup, or connect the MCP servers manually.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+<Card title="Agent Plugin" icon="robot" href="/developer-resources/build-with-ai-coding-agents">
+  One install bundles both MCP servers and all skills for Claude Code, Codex CLI, Cursor, and OpenCode
+</Card>
+
 <Card title="Dodo Knowledge MCP" icon="book-open" href="/developer-resources/mcp-server#dodo-knowledge-mcp">
   Semantic search across Dodo Payments documentation - get instant answers about features, APIs, and best practices
 </Card>


### PR DESCRIPTION
## Summary

Adds a new **"Build with AI Coding Agents"** hub page and surfaces the [Dodo Agent Plugin](https://github.com/dodopayments/dodo-agent-plugin) (v0.3.0) across existing docs.

The plugin bundles both MCP servers and eight integration skills in a single install for **Claude Code, Codex CLI, Cursor, and OpenCode**.

### New page

- **`developer-resources/build-with-ai-coding-agents.mdx`** — Comprehensive hub page covering:
  - Per-agent install instructions (AccordionGroup, Claude Code `defaultOpen`)
  - What you get (MCP servers table + skills table)
  - "Try this prompt first" example
  - Other supported agents (Windsurf, Claude Desktop, VS Code Copilot, Cline, Zed)
  - Docs built for agents (llms.txt, .md suffix)
  - What agents can do (feature bullet list with links)
  - Security & best practices
  - Optional local API-key config (Claude Code + OpenCode accordions)
  - Next steps (MCP Server, Agent Skills, Sentra, API Reference)

### Cross-references added

- **`introduction.mdx`** — Added "Install" bullet to "For AI Agents" accordion; renamed "MCP Servers for AI Assistants" → "Build with AI Coding Agents"; added Agent Plugin card (cols 2→3)
- **`developer-resources/mcp-server.mdx`** — Added "Agent Plugin (recommended)" as first tab in Quick Setup
- **`developer-resources/agent-skills.mdx`** — Added "Agent Plugin (recommended)" as first tab in Installation
- **`docs.json`** — Added `developer-resources/build-with-ai-coding-agents` nav entry after `agent-skills`

### Not touched

- Translated directories (`ar/`, `cn/`, `de/`, `es/`, `fr/`, `hi/`, `id/`, `it/`, `ja/`, `ko/`, `pt-BR/`, `sv/`, `vi/`) — left for i18n pipeline
- `changelog/` — deferred per user instruction

## Test plan

- [ ] `mintlify dev` — new page renders at `/developer-resources/build-with-ai-coding-agents`
- [ ] Nav entry visible under Docs → Integrate
- [ ] All internal links resolve (MCP Server, Agent Skills, Sentra, API Reference, features)
- [ ] No translated files modified (`git diff --stat | grep -E '^ar/|cn/|...'` returns empty)
- [ ] Install commands in 4 locations match the upstream README verbatim