### PR TITLE
docs(apps): add desktop app alongside mobile

### DIFF
--- a/features/communication-preferences.mdx
+++ b/features/communication-preferences.mdx
@@ -75,7 +75,7 @@ Push notifications are organized by device, allowing you to:
 - Manage multiple devices (e.g., phone and tablet)
 
 <Tip>
-Download the [Dodo Payments mobile app](/features/mobile-app) to receive push notifications on your iOS or Android device.
+Download the [Dodo Payments mobile or desktop app](/features/mobile-app) to receive push notifications on your iOS, Android, macOS, Windows, or Linux device.
 </Tip>
 
 ## Managing Email Recipients

--- a/features/mobile-app.mdx
+++ b/features/mobile-app.mdx
@@ -55,10 +55,10 @@ All the features of the web dashboard are fully available across the mobile and 
 Take Dodo Payments anywhere. Pair with the desktop app for a seamless workflow.
 
 <CardGroup cols={2}>
-  <Card title="iOS" icon="apple" href="https://dodopayments.com/downloads">
+  <Card title="iOS" icon="apple" href="https://apps.apple.com/in/app/dodo-payments/id6743651329">
     Download from the Apple App Store
   </Card>
-  <Card title="Android" icon="google-play" href="https://dodopayments.com/downloads">
+  <Card title="Android" icon="google-play" href="https://play.google.com/store/apps/details?id=com.dodopayments.app">
     Download from Google Play
   </Card>
 </CardGroup>

--- a/features/mobile-app.mdx
+++ b/features/mobile-app.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Android & iOS Mobile App"
-description: "Manage your Dodo Payments business on the go with our mobile app, available on Google Play and Apple App Store. Monitor transactions, receive real-time notifications, and access your dashboard anywhere."
+title: "Mobile & Desktop Apps"
+description: "Manage your Dodo Payments business from anywhere with our mobile and desktop apps. Available on iOS, Android, macOS, Windows, and Linux. Monitor transactions, receive real-time notifications, and access your dashboard wherever you work."
 icon: "mobile"
-keywords: ["Dodo Payments", "android & ios mobile app", "payment platform", "SaaS billing"]
+keywords: ["Dodo Payments", "mobile app", "desktop app", "iOS", "Android", "macOS", "Windows", "Linux", "payment platform", "SaaS billing"]
 ---
 
 ## Introduction
@@ -18,9 +18,9 @@ keywords: ["Dodo Payments", "android & ios mobile app", "payment platform", "Saa
   ></iframe>
 </Frame>
 
-Manage your payments, subscriptions, and business activity — anytime, anywhere. The **Dodo Payments Mobile App** brings the power of the Dodo Dashboard to your fingertips, allowing you to stay connected to your revenue, customers, and activity in real time.
+Manage your payments, subscriptions, and business activity — anytime, anywhere. The **Dodo Payments apps** bring the power of the Dodo Dashboard to your phone and your desktop, so you stay connected to your revenue, customers, and activity in real time.
 
-Whether you're commuting, traveling, or just away from your desk, you'll never miss an important update again.
+Whether you're commuting, traveling, or heads-down at your workstation, you'll never miss an important update again.
 
 ## Key Features
 
@@ -28,20 +28,20 @@ Whether you're commuting, traveling, or just away from your desk, you'll never m
   <Card title="Real-time Notifications" icon="bell">
     Get instant alerts for new transactions, payouts, subscription renewals, and verification status updates
   </Card>
-  <Card title="Dashboard on the Go" icon="chart-line">
-    View your revenue, transaction history, customer statistics, and visual performance graphs
+  <Card title="Dashboard Anywhere" icon="chart-line">
+    View your revenue, transaction history, customer statistics, and visual performance graphs on mobile or desktop
   </Card>
   <Card title="Subscription Management" icon="repeat">
     Monitor all active subscriptions and check individual customer details
   </Card>
   <Card title="Product Management" icon="box">
-    Create and manage products directly from your mobile device
+    Create and manage products directly from your phone or desktop
   </Card>
 </CardGroup>
 
-## Parity with Desktop Dashboard
+## Parity with the Web Dashboard
 
-All the features of the desktop version are fully available in the mobile app, including:
+All the features of the web dashboard are fully available across the mobile and desktop apps, including:
 
 - Test Mode and Live Mode switching
 - Verification progress and submission
@@ -50,11 +50,35 @@ All the features of the desktop version are fully available in the mobile app, i
 
 ## Download Now
 
+### Mobile
+
+Take Dodo Payments anywhere. Pair with the desktop app for a seamless workflow.
+
 <CardGroup cols={2}>
-  <Card title="Android" icon="google-play" href="https://play.google.com/store/apps/details?id=com.dodopayments.app">
-    Download from Google Play Store
+  <Card title="iOS" icon="apple" href="https://dodopayments.com/downloads">
+    Download from the Apple App Store
   </Card>
-  <Card title="iOS" icon="apple" href="https://apps.apple.com/in/app/dodo-payments/id6743651329">
-    Download from Apple App Store
+  <Card title="Android" icon="google-play" href="https://dodopayments.com/downloads">
+    Download from Google Play
   </Card>
 </CardGroup>
+
+### Desktop
+
+All of Dodo Payments, in one app. Native installers for macOS, Windows, and Linux.
+
+<CardGroup cols={3}>
+  <Card title="macOS" icon="apple" href="https://dodopayments.com/downloads">
+    Apple Silicon and Intel builds
+  </Card>
+  <Card title="Windows" icon="windows" href="https://dodopayments.com/downloads">
+    Setup installer and MSI
+  </Card>
+  <Card title="Linux" icon="linux" href="https://dodopayments.com/downloads">
+    AppImage, .deb, and .rpm
+  </Card>
+</CardGroup>
+
+<Tip>
+Visit [dodopayments.com/downloads](https://dodopayments.com/downloads) for the latest versions of every app, including direct links to each platform installer.
+</Tip>


### PR DESCRIPTION
## Summary
- The Dodo Payments desktop app (macOS, Windows, Linux) is now available at [dodopayments.com/downloads](https://dodopayments.com/downloads). This PR surfaces it in the docs alongside the existing mobile app so users can discover every native client in one place.
- Expanded `features/mobile-app.mdx` into **Mobile & Desktop Apps** with a Mobile section (iOS, Android) and a Desktop section (macOS, Windows, Linux). Reframed the parity section as parity with the **web dashboard** (mobile and desktop are now both first-class).
- Updated the push-notification tip in `features/communication-preferences.mdx` to mention desktop devices.

## Notes
- Translation directories are intentionally untouched — this PR covers the English source only. Localized versions can follow in a separate pass.
- Download links point to the central [dodopayments.com/downloads](https://dodopayments.com/downloads) page so docs don't need to be updated on every desktop release.
- `docs.json` navigation is unchanged: it references the page by slug, so Mintlify will pick up the new title from the frontmatter automatically.
- The `v1.13.0` changelog (mobile launch) was deliberately left as-is. The desktop launch belongs in its own future changelog entry.

## Files changed
- `features/mobile-app.mdx` — retitled to "Mobile & Desktop Apps", added Desktop download cards
- `features/communication-preferences.mdx` — push-notification tip now mentions desktop