### PR TITLE
docs(miscellaneous): add renewal failure test guide and renumber FAQs

### DIFF
--- a/miscellaneous/faq.mdx
+++ b/miscellaneous/faq.mdx
@@ -112,13 +112,9 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   A: No, changing the primary brand is not supported. As a workaround, you can swap the brand names — update your secondary brand's name to the one you want as primary, and vice versa.
 </Accordion>
 
-<Accordion title="Q23: Can I remove or delete a brand from my account?">
-  A: No. Brands cannot be deleted or removed. If a brand is not in use, simply ignore it — it won't affect your account or operations.
-</Accordion>
-
 ## Verification, Tax & Compliance
 
-<Accordion title="Q24: Why is my verification taking so long?">
+<Accordion title="Q23: Why is my verification taking so long?">
   A: Dodo Payments typically takes 24–72 working hours to process verifications. However, delays can occur due to:
   - High volume of applications
   - Weekends and public holidays
@@ -130,7 +126,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Note>
 </Accordion>
 
-<Accordion title="Q25: I chose the wrong registration type (business vs individual). How can I fix it?">
+<Accordion title="Q24: I chose the wrong registration type (business vs individual). How can I fix it?">
   A: If you selected the wrong entity type (e.g., chose "Organization" but you're an individual or a Sole Prop with GST), your verification might be On-hold, requiring you to change or update the documentation.
 
   Steps to fix:
@@ -139,7 +135,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
 
 </Accordion>
 
-<Accordion title="Q26: Can I use a different name (like my parent's) to sign up and get verified?">
+<Accordion title="Q25: Can I use a different name (like my parent's) to sign up and get verified?">
   A: Yes, this is allowed. However, KYC, bank details, and ownership must be under the parent's name.
 
   If your parent is the actual business owner:
@@ -151,7 +147,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Note>
 </Accordion>
 
-<Accordion title="Q27: How do I check the reason for verification rejection?">
+<Accordion title="Q26: How do I check the reason for verification rejection?">
   A: You can find the reason in the Dodo Payments dashboard, under the verification section.
 
   <Tip>
@@ -159,7 +155,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Tip>
 </Accordion>
 
-<Accordion title="Q28: Can I create a new business account if my previous one was declined?">
+<Accordion title="Q27: Can I create a new business account if my previous one was declined?">
   A: Yes — but only if:
   - You've fixed the issues that led to rejection.
   - You're not attempting to bypass risk decisions (e.g., deboarding for fraud concerns).
@@ -169,7 +165,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Note>
 </Accordion>
 
-<Accordion title="Q29: I've been told my account was previously deboarded. What does this mean?">
+<Accordion title="Q28: I've been told my account was previously deboarded. What does this mean?">
   A: If you see a message stating your account was previously deboarded by the risk team:
   - It means Dodo Payments found significant compliance or risk issues with your activity or business.
   - Attempting to create new accounts using the same identity or business details will likely be rejected again.
@@ -179,7 +175,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Note>
 </Accordion>
 
-<Accordion title="Q30: How do I get my payout verification cleared faster?">
+<Accordion title="Q29: How do I get my payout verification cleared faster?">
   A: To avoid delays:
   - Submit clear, properly formatted documents
   - Avoid repeated messages/tags in Discord — this slows the queue
@@ -191,22 +187,22 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Tip>
 </Accordion>
 
-<Accordion title="Q31: I have a GST with a trade name. Is that considered an organization?">
+<Accordion title="Q30: I have a GST with a trade name. Is that considered an organization?">
   A: No. If you're registered with a GST as an individual (sole proprietor), you're still considered an Individual. Incorrect information provided during registration can be updated by contacting support.
 
   ✅ Select "Individual" in the registration
   ❌ Do not select "Organization" unless you're a registered legal entity
 </Accordion>
 
-<Accordion title="Q32: How does Dodo Payments handle GST for Indian SaaS merchants?">
+<Accordion title="Q31: How does Dodo Payments handle GST for Indian SaaS merchants?">
   A: Dodo Payments automatically calculates and applies **GST** for Indian merchants based on your customer's location.
 </Accordion>
 
-<Accordion title="Q33: Does Dodo Payments handle international sales?">
+<Accordion title="Q32: Does Dodo Payments handle international sales?">
   A: Yes, Dodo Payments supports international sales and manages all associated compliances.
 </Accordion>
 
-<Accordion title="Q34: Are address data such as city, state, zipcode fields mandatory? Can I exclude requesting those values from my customer?">
+<Accordion title="Q33: Are address data such as city, state, zipcode fields mandatory? Can I exclude requesting those values from my customer?">
   A: Yes, they are mandatory. As we are the Merchant of Record, we require the customer's billing address to:
 
   - Generate invoices
@@ -216,12 +212,12 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   You can implement our API-based checkout flow to pre-fill customer details if you have already collected them, ensuring a smoother experience. However, we will need these details for every purchase.
 </Accordion>
 
-<Accordion title="Q35: Do I need to file taxes in the US if I sell there?">
+<Accordion title="Q34: Do I need to file taxes in the US if I sell there?">
   A: Not directly. Dodo Payments acts as the Merchant of Record, handles customer-side tax, and remits where applicable. We no longer require tax forms. You still need to file income tax in your home country (e.g., India).
 
 </Accordion>
 
-<Accordion title="Q36: Do I need a PAN or GST to receive payments? (For Indian Nationals Only)">
+<Accordion title="Q35: Do I need a PAN or GST to receive payments? (For Indian Nationals Only)">
   A: **For Indian Individuals:**
   - PAN is mandatory (for KYC and tax purposes)
 
@@ -233,7 +229,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   - Equivalent identity and tax documentation from your country of residence will be required during the verification process
 </Accordion>
 
-<Accordion title="Q37: I have a Udyam/MSME certificate. How does this affect my registration?">
+<Accordion title="Q36: I have a Udyam/MSME certificate. How does this affect my registration?">
   A: A Udyam/MSME certificate is applicable for both individuals and private entities. Having a Udyam/MSME certificate does not automatically make you an Organization. The registration type depends on your bank account type:
 
   - **If you operate with a personal bank account** (even with Udyam/MSME certificate): You're considered an **Individual**
@@ -244,7 +240,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   </Note>
 </Accordion>
 
-<Accordion title="Q38: Can I create an account if I am below 18?">
+<Accordion title="Q37: Can I create an account if I am below 18?">
   A: Yes, Dodo Payments does support merchants who are under 18, provided that your business is signed up with a parent or guardian's details. All documents and bank account details must belong to a parent or guardian, and all payouts will be disbursed to their bank account. Once you turn 18, you can update the account details to your own information.
 
   To proceed with verification, the following documents are required:
@@ -257,77 +253,77 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   For any questions, please reach out to support@dodopayments.com.
 </Accordion>
 
-<Accordion title="Q39: Why is my ID verification form failing?">
+<Accordion title="Q38: Why is my ID verification form failing?">
   A: Please ensure you are using a physical ID document (not a screenshot or photocopy) and capturing a live photo. Try switching browsers or devices, and make sure you are in a well-lit environment so the system can accurately capture your details.
 </Accordion>
 
-<Accordion title="Q40: Is there any tax form I need to submit?">
+<Accordion title="Q39: Is there any tax form I need to submit?">
   A: The only mandatory tax form is the **W-8BEN-E**, and it is required only if you are a registered entity in the UK.
 </Accordion>
 
-<Accordion title="Q41: What details are required in the Product Verification Form (PVF)?">
+<Accordion title="Q40: What details are required in the Product Verification Form (PVF)?">
   A: All details in the PVF must accurately match the information on your website. Ensure that your website is live, accessible, and reflects the same information provided in the form.
 </Accordion>
 
-<Accordion title="Q42: What happens if my form is rejected?">
+<Accordion title="Q41: What happens if my form is rejected?">
   A: You can view the reason for rejection on your dashboard. If you believe the rejection was incorrect, you may file an appeal (only once).
 </Accordion>
 
-<Accordion title="Q43: How do I file an appeal?">
+<Accordion title="Q42: How do I file an appeal?">
   A: Follow the dashboard navigation to file an appeal. Ensure your explanation is detailed and not a one-liner. For additional clarification, you may contact support@dodopayments.com.
 </Accordion>
 
-<Accordion title="Q44: How long does it take for an appeal to be reviewed?">
+<Accordion title="Q43: How long does it take for an appeal to be reviewed?">
   A: Appeals typically take more than **48 working hours** to be reviewed.
 </Accordion>
 
-<Accordion title="Q45: What happens if my appeal is rejected?">
+<Accordion title="Q44: What happens if my appeal is rejected?">
   A: An appeal rejection is considered final. Rejections usually occur if the product violates merchant acceptance policies, is incomplete, or still under development. You may create a new account after addressing the issues identified. For further clarification, please contact support@dodopayments.com.
 </Accordion>
 
-<Accordion title="Q46: Can I change or update my registration type (Individual ↔ Business)?">
+<Accordion title="Q45: Can I change or update my registration type (Individual ↔ Business)?">
   A: Yes. You can switch between Individual and Business account types at any time. To do this, contact support via Intercom and request resubmission access. Once enabled, go to the verification section on your dashboard, select the correct registration type, and resubmit your documents. This change will not impact your existing subscriptions or payments.
 </Accordion>
 
-<Accordion title="Q47: My verification is On-Hold — what does that mean?">
+<Accordion title="Q46: My verification is On-Hold — what does that mean?">
   A: On-Hold means our compliance team needs additional information or documents from you. Check your dashboard for the specific requirement. You can also contact support@dodopayments.com with your registered email for clarification.
 </Accordion>
 
-<Accordion title="Q48: What happens to my existing subscriptions and payments if I get deboarded?">
+<Accordion title="Q47: What happens to my existing subscriptions and payments if I get deboarded?">
   A: If your account is deboarded, only live payments will be disabled — you will no longer be able to receive new payments. Existing subscriptions and historical payment data will not be affected.
 </Accordion>
 
 ## Payments & Transactions
 
-<Accordion title="Q49: What types of payments can I accept with Dodo Payments?">
+<Accordion title="Q48: What types of payments can I accept with Dodo Payments?">
   A: Dodo Payments supports a variety of payment methods, including **credit cards**, **debit cards**, and **digital wallets**. We also support one-time payments and recurring subscription payments for digital products.
 </Accordion>
 
-<Accordion title="Q50: Why was the first payment marked successful with an amount of $0 for subscription?">
+<Accordion title="Q49: Why was the first payment marked successful with an amount of $0 for subscription?">
   A: If a product has a trial period, the first payment automatically becomes a mandate payment of $0. This is expected behavior and confirms that the mandate has been created successfully.
 </Accordion>
 
-<Accordion title="Q51: After the trial period ends, does the customer need to pay (product price(e.g $25)) again manually?">
+<Accordion title="Q50: After the trial period ends, does the customer need to pay (product price(e.g $25)) again manually?">
   A: No. Once the trial ends, the system automatically generates the product price(e.g $25) for the customer. They do not need to pay it manually.
 </Accordion>
 
-<Accordion title="Q52: What if the trial period shows differently on my app vs. the Dodo Payments dashboard?">
+<Accordion title="Q51: What if the trial period shows differently on my app vs. the Dodo Payments dashboard?">
   A: This usually indicates a setup or implementation issue on your end. Test the trial + subscription flow in test mode first, confirm it's working, and then switch to live mode.
 </Accordion>
 
-<Accordion title="Q53: Do I need to test the trial feature before going live?">
+<Accordion title="Q52: Do I need to test the trial feature before going live?">
   A: Yes. It's recommended to fully implement and test the feature in test mode to ensure everything works correctly before switching to live mode.
 </Accordion>
 
-<Accordion title="Q54: How can I track payment statuses?">
+<Accordion title="Q53: How can I track payment statuses?">
   A: You can track the status of payments from the **Payments** section of your dashboard. Each transaction is listed with a status indicator: **In Progress**, **Failed**, or **Successful**.
 </Accordion>
 
-<Accordion title="Q55: What should I do if a payment fails?">
+<Accordion title="Q54: What should I do if a payment fails?">
   A: If a payment fails, check the **Payment Details Page** for more information. Common reasons include incorrect payment details, insufficient funds, or network issues. You can resend the payment link to your customer to retry the payment.
 </Accordion>
 
-<Accordion title="Q56: Do merchants get notified when a user's payment fails?">
+<Accordion title="Q55: Do merchants get notified when a user's payment fails?">
   A: Yes. Dodo Payments notifies the merchant when a user's payment fails through multiple channels in live mode:
   - Email notifications
   - Webhook events
@@ -336,7 +332,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
 This ensures merchants stay informed about failed transactions.
 </Accordion>
 
-<Accordion title="Q57: What happens to a subscription if a payment fails?">
+<Accordion title="Q56: What happens to a subscription if a payment fails?">
   A: The subscription is not cancelled immediately. Instead, it is moved to on-hold status until a successful payment is made.
 
   If you have an issue with the card, you can update the payment method by:
@@ -344,11 +340,11 @@ This ensures merchants stay informed about failed transactions.
   - Or using the API endpoint: https://docs.dodopayments.com/api-reference/subscriptions/update-payment-method
 </Accordion>
 
-<Accordion title="Q58: If I retry payments myself, do I need the failed payment ID?">
+<Accordion title="Q57: If I retry payments myself, do I need the failed payment ID?">
   A: No. You only need the subscription ID to initiate a new payment attempt.
 </Accordion>
 
-<Accordion title="Q59: How can a subscription payment fail with INCORRECT_NUMBER if previous cycles were successful?">
+<Accordion title="Q58: How can a subscription payment fail with INCORRECT_NUMBER if previous cycles were successful?">
   A: A subscription payment can fail with `INCORRECT_NUMBER` if the customer's card was:
 
   - Cancelled
@@ -359,7 +355,7 @@ This ensures merchants stay informed about failed transactions.
   This can happen after the previous billing cycle. Dodo Payments simply displays the error message returned by the payment provider.
 </Accordion>
 
-<Accordion title="Q60: Does the chargeback apply for business even if my business has a no refund policy?">
+<Accordion title="Q59: Does the chargeback apply for business even if my business has a no refund policy?">
   A: Yes. A "No refund" policy does not override the card network's dispute resolution process. Chargebacks are governed by the cardholder's bank and card network rules (e.g., Visa, Mastercard).
 
   If a customer files a dispute:
@@ -372,7 +368,7 @@ This ensures merchants stay informed about failed transactions.
   </Tip>
 </Accordion>
 
-<Accordion title="Q61: Why is payment.status sometimes null?">
+<Accordion title="Q60: Why is payment.status sometimes null?">
   A: payment.status can be null for a short time:
   - Right after creation but before processing completes
   - During subscription billing failures or retries
@@ -384,13 +380,13 @@ This ensures merchants stay informed about failed transactions.
   </Note>
 </Accordion>
 
-<Accordion title="Q62: Why is product_cart null even though it's a checkout in webhook payload?">
+<Accordion title="Q61: Why is product_cart null even though it's a checkout in webhook payload?">
   A:
   - For subscription payments, product_cart is empty because there's no one-time item being bought
   - product_cart is only populated for one-time payments
 </Accordion>
 
-<Accordion title="Q63: Why was my real card blocked during testing?">
+<Accordion title="Q62: Why was my real card blocked during testing?">
   A: You likely tested in Live Mode instead of Test Mode.
 
   Live payments:
@@ -403,14 +399,14 @@ This ensures merchants stay informed about failed transactions.
   - Test card numbers provided in the documentation
 </Accordion>
 
-<Accordion title="Q64: My customer completed payment but I didn't receive webhook?">
+<Accordion title="Q63: My customer completed payment but I didn't receive webhook?">
   A: Checklist:
   - Confirm webhook is configured in Dashboard > Developers -> Webhooks
   - Check if webhook is failing silently due to non-2xx response
   - Check logs: was a 429 or timeout returned?
 </Accordion>
 
-<Accordion title="Q65: Why is my dashboard showing success, but my app didn't update?">
+<Accordion title="Q64: Why is my dashboard showing success, but my app didn't update?">
   A: It's likely you're relying solely on redirect_url query params and not handling:
   - Webhooks
   - API confirmation call
@@ -420,7 +416,7 @@ This ensures merchants stay informed about failed transactions.
   - Or query the API to confirm transaction after redirect
 </Accordion>
 
-<Accordion title="Q66: I'm not seeing UPI as a payment option — why?">
+<Accordion title="Q65: I'm not seeing UPI as a payment option — why?">
   A: UPI may not appear as a payment option for several reasons:  
   - The billing country is not set to India (IN).  
   - Adaptive Currency is disabled.  
@@ -428,7 +424,7 @@ This ensures merchants stay informed about failed transactions.
   Note: If you are a non-Indian merchant and Adaptive Currency is not enabled, UPI will not be available for your customers.
 </Accordion>
 
-<Accordion title="Q67: Does Dodo support UPI for subscriptions?">
+<Accordion title="Q66: Does Dodo support UPI for subscriptions?">
   A: Yes, UPI subscriptions are supported with RBI-compliant mandates. UPI subscriptions operate under RBI (Reserve Bank of India) regulations with specific requirements:
 
   - **Mandate Limits**:
@@ -442,15 +438,15 @@ This ensures merchants stay informed about failed transactions.
   </Note>
 </Accordion>
 
-<Accordion title="Q68: How do I enable Google Pay / Apple Pay on static payment links?">
+<Accordion title="Q67: How do I enable Google Pay / Apple Pay on static payment links?">
   A: Google Pay and Apple Pay automatically appear on static payment links in live mode. You do not need to take any additional steps to enable them.
 </Accordion>
 
-<Accordion title="Q69: How can I enable 3DS in Dodo Payments?">
+<Accordion title="Q68: How can I enable 3DS in Dodo Payments?">
   A: You can enable 3DS directly from the Dodo Payments dashboard. Simply go to **Settings → Business** and turn on the 3DS option under Payment Settings.
 </Accordion>
 
-<Accordion title="Q70: How do I collect billing details without passing them in API?">
+<Accordion title="Q69: How do I collect billing details without passing them in API?">
   A: If you want users to enter billing info themselves:
   - Use static links, which automatically collect billing
   - For dynamic flows, you must collect info manually and pass it in the API
@@ -458,7 +454,7 @@ This ensures merchants stay informed about failed transactions.
   There's no built-in UI yet for collecting billing during dynamic link creation.
 </Accordion>
 
-<Accordion title="Q71: What's the difference between static and dynamic payment links?">
+<Accordion title="Q70: What's the difference between static and dynamic payment links?">
   A: **Static payment links** are no-code options meant for quick use. They:
   - Are configured from the dashboard
   - Automatically collect billing info
@@ -473,14 +469,14 @@ This ensures merchants stay informed about failed transactions.
   </Tip>
 </Accordion>
 
-<Accordion title="Q72: Will I get two webhook events when someone starts a subscription?">
+<Accordion title="Q71: Will I get two webhook events when someone starts a subscription?">
   A: On the first successful subscription payment, you will typically receive these three webhooks if no trial period is involved:
   - `subscription.active` webhook
   - `payment.succeeded` webhook
   - `subscription.renewed` webhook
 </Accordion>
 
-<Accordion title="Q73: What does subscription.cancelled_at mean? Is it a scheduled cancellation?">
+<Accordion title="Q72: What does subscription.cancelled_at mean? Is it a scheduled cancellation?">
   A: Dodo supports both immediate and scheduled cancellations.
 
   When a cancellation request is made:
@@ -489,7 +485,7 @@ This ensures merchants stay informed about failed transactions.
 
 </Accordion>
 
-<Accordion title="Q74: When does a subscription get charged?">
+<Accordion title="Q73: When does a subscription get charged?">
   A: Dodo Payments charges the customer immediately upon subscription creation if the product does not have a trial period.
 
   <Note>
@@ -497,26 +493,26 @@ This ensures merchants stay informed about failed transactions.
   </Note>
 </Accordion>
 
-<Accordion title="Q75: Why does the Change Plan API return an empty response?">
+<Accordion title="Q74: Why does the Change Plan API return an empty response?">
   A: The Change Plan API returns only a 200 status code with no response body, so the response will appear empty even though the plan change is successful.
 </Accordion>
 
-<Accordion title="Q76: Why wasn't a new payment prompted when switching from a monthly to an annual plan?">
+<Accordion title="Q75: Why wasn't a new payment prompted when switching from a monthly to an annual plan?">
   A: When changing plans, Dodo Payments automatically charges the saved card. If the charge fails, the subscription is moved to "on hold." So no manual payment flow is triggered.
 </Accordion>
 
-<Accordion title="Q77: Why does my product price (Rs 100) show a higher amount (Rs 104) during checkout?">
+<Accordion title="Q76: Why does my product price (Rs 100) show a higher amount (Rs 104) during checkout?">
   A: This happens when Adaptive Currency is enabled. The feature adds an additional 4% charge automatically.
 </Accordion>
 
-<Accordion title="Q78: Why does checkout ignore existing active subscriptions and create a new one?">
+<Accordion title="Q77: Why does checkout ignore existing active subscriptions and create a new one?">
   A: Checkout always creates a new subscription. It does not check whether the customer already has an active subscription. Your application must block existing subscribers from starting a checkout session to avoid duplicate charges.
 </Accordion>
 
 
 
 
-<Accordion title="Q79: Why am I seeing a TRANSACTION_NOT_ALLOWED error during a subscription upgrade/downgrade?">
+<Accordion title="Q78: Why am I seeing a TRANSACTION_NOT_ALLOWED error during a subscription upgrade/downgrade?">
   A: This error comes from the card issuer, not Dodo Payments. The bank is blocking the transaction due to restrictions on that card.
 
   Common reasons:
@@ -526,40 +522,40 @@ This ensures merchants stay informed about failed transactions.
   - Prepaid or restricted cards may not support these payments
 </Accordion>
 
-<Accordion title="Q80: Is there a way to test in live mode without making real payments?">
+<Accordion title="Q79: Is there a way to test in live mode without making real payments?">
   A: Yes. You can test live-mode checkout flows by creating a 100% discount code. This allows you to complete the full payment and redirect flow without being charged.
 </Accordion>
 
-<Accordion title="Q81: What is the $0 payment method?">
+<Accordion title="Q80: What is the $0 payment method?">
   A: A $0 payment occurs when the total payable amount becomes zero (e.g., by applying a 100% discount). In such cases, no actual payment is processed, but the checkout and subscription flow still work normally.
 </Accordion>
 
 
-<Accordion title="Q82: It seems my account appears to be suspended, but compliance says everything is fine. What should I do?">
+<Accordion title="Q81: It seems my account appears to be suspended, but compliance says everything is fine. What should I do?">
   A: In most cases, this happens because you've accidentally switched to an old or inactive business account. Simply switch back to your active business account in the Dodo Payments dashboard. If the issue continues after switching, contact Dodo Payments Support for assistance.
 </Accordion>
 
-<Accordion title="Q83: Do you support ACH payments?">
+<Accordion title="Q82: Do you support ACH payments?">
   A: No, ACH payments are not currently supported.
 </Accordion>
 
-<Accordion title="Q84: Is PayPal supported?">
+<Accordion title="Q83: Is PayPal supported?">
   A: PayPal is currently paused. We don't have an ETA for when it will be available. Once it's live, we'll update our docs.
 </Accordion>
 
-<Accordion title="Q85: What currencies does Dodo Payments natively support?">
+<Accordion title="Q84: What currencies does Dodo Payments natively support?">
   A: Dodo Payments natively supports four currencies: USD, INR, GBP, and EUR. For other currencies, you can enable Adaptive Pricing to automatically convert prices to your customer's local currency.
 </Accordion>
 
-<Accordion title="Q86: How are FX conversion charges calculated?">
+<Accordion title="Q85: How are FX conversion charges calculated?">
   A: FX conversion charges are applied based on the exchange rate on the day the transaction is processed. Rates vary daily based on market fluctuations.
 </Accordion>
 
-<Accordion title="Q87: Which countries does Dodo Payments accept payments from?">
+<Accordion title="Q86: Which countries does Dodo Payments accept payments from?">
   A: See the full list of supported countries here: https://docs.dodopayments.com/miscellaneous/list-of-countries-we-accept-payments-from
 </Accordion>
 
-<Accordion title="Q88: How do I add an addon to an existing subscription?">
+<Accordion title="Q87: How do I add an addon to an existing subscription?">
   A: Use the Change Plan API with the same product_id and include the addons array. The addon will be added without changing the base plan, and the customer will be charged a prorated amount immediately.
 
 Example:
@@ -576,25 +572,25 @@ POST /subscriptions/{subscription_id}/change-plan
 ```
 </Accordion>
 
-<Accordion title="Q89: How long can a subscription stay in On-Hold state?">
+<Accordion title="Q88: How long can a subscription stay in On-Hold state?">
   A: A subscription stays On-Hold until the customer updates their payment method and a successful payment is made. You can update the payment method only after a payment has failed — not while the current card is still valid.
 </Accordion>
 
-<Accordion title="Q90: Can I make tax inclusive in the product price?">
+<Accordion title="Q89: Can I make tax inclusive in the product price?">
   A: Yes. Go to Dashboard → Products → Edit Product → Pricing → enable Tax Inclusive Pricing. Taxes are automatically calculated based on the customer's location — there's no fixed tax list to manage.
 </Accordion>
 
-<Accordion title="Q91: Can addons have their own brand?">
+<Accordion title="Q90: Can addons have their own brand?">
   A: No. Add-ons cannot be purchased standalone and don't support branding directly. The brand is defined on the base product. Attach the brand to the main product and then add your add-ons to it.
 </Accordion>
 
-<Accordion title="Q92: Can I switch a product to a different brand?">
+<Accordion title="Q91: Can I switch a product to a different brand?">
   A: No. Brands are selected at the Product level and cannot be switched after the product is created. Create a new product under the desired brand if needed.
 </Accordion>
 
 ## Payouts & Bank Integration
 
-<Accordion title="Q93: How do payouts work with Dodo Payments?">
+<Accordion title="Q92: How do payouts work with Dodo Payments?">
   A: Payouts are the transfer of your collected sales revenue to your linked bank account. Dodo Payments supports multiple payout cycles:
 
   - **Bi-Monthly (Default)**:
@@ -611,7 +607,7 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q94: What is the minimum threshold amount after fees and taxes to process payouts?">
+<Accordion title="Q93: What is the minimum threshold amount after fees and taxes to process payouts?">
   A: The minimum payout threshold after platform fees and taxes deduction is:
 
   - **USD**: $50
@@ -626,22 +622,22 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q95: How do I link my bank account to receive payouts?">
+<Accordion title="Q94: How do I link my bank account to receive payouts?">
   A: To link your bank account, navigate to **Payouts** in your dashboard and click **Add Bank Account**. You'll need to enter your bank details and verify the account.
 </Accordion>
 
-<Accordion title="Q96: Can I track the status of my payouts?">
+<Accordion title="Q95: Can I track the status of my payouts?">
   A: Yes, you can track your payout status from the **Payouts** section of the dashboard.
 </Accordion>
 
-<Accordion title="Q97: What are payout fees and how much are they?">
+<Accordion title="Q96: What are payout fees and how much are they?">
   A: Payout fees are the transaction costs for transferring collected revenue to your bank account.
 
   - We constantly work to reduce fees by partnering with local partners in your country
   - Please refer to the [pricing page](https://dodopayments.com/pricing) for detailed information
 </Accordion>
 
-<Accordion title="Q98: I received a &quot;payout processed&quot; email — when will the funds arrive?">
+<Accordion title="Q97: I received a &quot;payout processed&quot; email — when will the funds arrive?">
   A: Payouts usually take 1–2 business days to reflect in your bank account.
 
   <Note>
@@ -649,11 +645,11 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q99: How do I add Payoneer as a payout account?">
+<Accordion title="Q98: How do I add Payoneer as a payout account?">
   A: Just enter your Payoneer bank details in the Bank Info Form under your dashboard. There's no separate Payoneer integration yet.
 </Accordion>
 
-<Accordion title="Q100: Can I receive payouts to a Payoneer account?">
+<Accordion title="Q99: Can I receive payouts to a Payoneer account?">
   A: Yes. You can receive payouts via Payoneer by:
   - Entering your Payoneer account details in the Bank Info Form on the Dodo dashboard
   - Ensure your account is approved and supports USD or the currency you're withdrawing
@@ -661,12 +657,12 @@ POST /subscriptions/{subscription_id}/change-plan
   There is no dedicated Payoneer integration — it is treated as a regular bank account.
 </Accordion>
 
-<Accordion title="Q101: My bank info is still in review — what should I do?">
+<Accordion title="Q100: My bank info is still in review — what should I do?">
   A: No compliance form is required anymore. For bank info review, just wait. Our team typically reviews bank details within 1–2 working days. If it's urgent:
   - Email support@dodopayments.com
 </Accordion>
 
-<Accordion title="Q102: What happens if my payout day falls on a Friday or weekend?">
+<Accordion title="Q101: What happens if my payout day falls on a Friday or weekend?">
   A: If your payout day is on a Friday, it is usually processed on the same day. However:
   - If there's a bank holiday or weekend, it may be delayed to the next working day (usually Monday).
   - The exact timing may depend on your bank's processing rules.
@@ -676,14 +672,14 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q103: How can I expedite payout compliance if I have an urgent launch or ad campaign planned?">
+<Accordion title="Q102: How can I expedite payout compliance if I have an urgent launch or ad campaign planned?">
   A: If you've submitted everything and are awaiting payout compliance:
   - Mention your urgency clearly in support chats (e.g., live launch, paid campaigns).
   - Include your business ID and email.
   - Avoid spamming or tagging multiple team members — this may slow down the queue.
 </Accordion>
 
-<Accordion title="Q104: I submitted the wrong bank account details. How do I update them?">
+<Accordion title="Q103: I submitted the wrong bank account details. How do I update them?">
   A: If you've entered incorrect bank details:
   - Contact support via Intercom or Mail.
   - Wait for the compliance team to reopen the section for you to re-submit.
@@ -693,11 +689,11 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q105: Can I use my personal bank account if I have a registered company?">
+<Accordion title="Q104: Can I use my personal bank account if I have a registered company?">
   A: No. If you're registered as a company or legal entity, you must use the entity's bank account.
 </Accordion>
 
-<Accordion title="Q106: My country doesn't use SWIFT codes. How will that affect my verification?">
+<Accordion title="Q105: My country doesn't use SWIFT codes. How will that affect my verification?">
   A: If your country does not issue SWIFT codes, this will not block your verification.
 
   What to do:
@@ -713,7 +709,7 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q107: What alternative documentation can I provide if my country doesn't use SWIFT codes?">
+<Accordion title="Q106: What alternative documentation can I provide if my country doesn't use SWIFT codes?">
   A: If your country doesn't use SWIFT codes, provide the following alternative documentation:
 
   - Official bank statement or certificate showing your account details
@@ -725,46 +721,46 @@ POST /subscriptions/{subscription_id}/change-plan
   </Tip>
 </Accordion>
 
-<Accordion title="Q108: Can I set a payout threshold lower than $50?">
+<Accordion title="Q107: Can I set a payout threshold lower than $50?">
   A: No. The minimum payout threshold is **$50** and cannot be lowered.
 
   - You **can** increase the threshold above $50
   - You **cannot** set it below $50
 </Accordion>
 
-<Accordion title="Q109: Do you support daily payouts?">
+<Accordion title="Q108: Do you support daily payouts?">
   A: No, daily payouts are not available. The available payout cycles are bi-monthly (default), weekly (for high-volume businesses), and monthly. See full details: https://docs.dodopayments.com/features/payouts/payout-structure#payout-cycles
 </Accordion>
 
 ## Invoicing & Reports
 
-<Accordion title="Q110: Does Dodo Payments generate invoices automatically?">
+<Accordion title="Q109: Does Dodo Payments generate invoices automatically?">
   A: Yes, Dodo Payments automatically generates **invoices** for every successful transaction. These invoices include all necessary details such as tax breakdowns, customer information, and product details.
 </Accordion>
 
-<Accordion title="Q111: Can I customize the invoices?">
+<Accordion title="Q110: Can I customize the invoices?">
   A: Yes, you can customize the look of your invoices by adding your **company logo and brand name.** You can manage these settings in the Business Profile section of your dashboard.
 </Accordion>
 
-<Accordion title="Q112: How do I access or download an invoice?">
+<Accordion title="Q111: How do I access or download an invoice?">
   A: You can view or download invoices from the **Invoices** section of the dashboard. Each payment will have an associated invoice that can be downloaded as a **PDF**.
 </Accordion>
 
-<Accordion title="Q113: How do I view reports on my transactions and payouts?">
+<Accordion title="Q112: How do I view reports on my transactions and payouts?">
   A: You can generate detailed reports from the **Reports** section of your dashboard. These reports include data on transactions, refunds, and payouts, which you can filter by date and export in CSV format.
 </Accordion>
 
 ## Refunds & Disputes
 
-<Accordion title="Q114: How do I issue a refund?">
+<Accordion title="Q113: How do I issue a refund?">
   A: To issue a refund, go to the **Payment Details Page** of the transaction you want to refund and click the **Initiate Refund** button. You can issue a **full** or **partial** refund, provided the payment meets the refund eligibility rules.
 </Accordion>
 
-<Accordion title="Q115: How long does it take for a customer to receive their refund?">
+<Accordion title="Q114: How long does it take for a customer to receive their refund?">
   A: Once a refund is initiated, the customer will typically receive the refunded amount within **3-5 business days**, depending on the payment method and their bank.
 </Accordion>
 
-<Accordion title="Q116: I'm facing a dispute or chargeback. What can I do?">
+<Accordion title="Q115: I'm facing a dispute or chargeback. What can I do?">
   A: If a chargeback is filed against you:
   - You may lose both the transaction amount and a dispute fee
   - You can submit evidence of product delivery, usage logs, or customer communication
@@ -778,7 +774,7 @@ POST /subscriptions/{subscription_id}/change-plan
   </Note>
 </Accordion>
 
-<Accordion title="Q117: The customer disputed the charge after using the service. Can I appeal this?">
+<Accordion title="Q116: The customer disputed the charge after using the service. Can I appeal this?">
   A: Yes — you can:
   - Share documentation (chat logs, usage records, delivery confirmation)
   - Explain that the service was fulfilled
@@ -789,25 +785,25 @@ POST /subscriptions/{subscription_id}/change-plan
   </Tip>
 </Accordion>
 
-<Accordion title="Q118: Why is my refund failing with an 'insufficient funds' error?">
+<Accordion title="Q117: Why is my refund failing with an 'insufficient funds' error?">
   A: Refunds are checked against your available account balance, not your scheduled payout amount. If payouts are already scheduled, that amount is not counted as available. If your available balance is too low, the refund will fail. Wait for your next payout cycle to build up balance, or contact support.
 </Accordion>
 
 ## Webhooks & Integration
 
-<Accordion title="Q119: How is proration calculated — on the product price or the total amount?">
+<Accordion title="Q118: How is proration calculated — on the product price or the total amount?">
   A: Proration is calculated on the **total amount paid**, not just the base product price. 
   This means if a discount is applied, the proration is calculated on the **final amount after the discount**.
 </Accordion>
 
 
-<Accordion title="Q120: Why do we use the `subscription.renewed` webhook for the first subscription?">
+<Accordion title="Q119: Why do we use the `subscription.renewed` webhook for the first subscription?">
   A: After the first payment succeeds, the subscription enters its first billing period and the next billing date is set. 
   The `subscription.renewed` webhook is sent to indicate that a billing period is now active and the next billing cycle has been scheduled. 
   This webhook is used for every billing period—including the first one—so billing logic can be handled consistently each time.
 </Accordion>
 
-<Accordion title="Q121: Can I manually verify Dodo Payments webhooks in Python?">
+<Accordion title="Q120: Can I manually verify Dodo Payments webhooks in Python?">
   A: Yes. Manual verification is possible, but it must strictly follow the correct signing steps. For an easier and more reliable approach, Dodo Payments recommends using the standardwebhooks package:
   
   ```python
@@ -824,11 +820,11 @@ POST /subscriptions/{subscription_id}/change-plan
   ```
   </Accordion>
 
-<Accordion title="Q122: Where can I find official docs on manual webhook verification?">
+<Accordion title="Q121: Where can I find official docs on manual webhook verification?">
 A: You can refer to the official Dodo Payments documentation here: https://docs.dodopayments.com/developer-resources/webhooks#manual-verification-alternative
 </Accordion>
 
-<Accordion title="Q123: My webhook isn't receiving a POST request, only a GET. Why?">
+<Accordion title="Q122: My webhook isn't receiving a POST request, only a GET. Why?">
 A: You're likely confusing the redirect URL with the webhook URL. A redirect URL is where the user is sent after a payment, and it may contain `?subscription_id=...&status=active` in a GET request. This is not your webhook.
 
 To receive structured POST payloads from Dodo Payments:
@@ -840,7 +836,7 @@ You can have both a webhook and a redirect URL — they serve different purposes
 </Note>
 </Accordion>
 
-<Accordion title="Q124: I get a 401 Unauthorized error using the Python SDK. Why?">
+<Accordion title="Q123: I get a 401 Unauthorized error using the Python SDK. Why?">
 A: You likely forgot to pass the correct environment when initializing the DodoPayments client.
 
 <Check>
@@ -854,11 +850,11 @@ bearer_token="your_api_key",
 </Check>
 </Accordion>
 
-<Accordion title="Q125: Is there a way to manually trigger a webhook event for testing?">
+<Accordion title="Q124: Is there a way to manually trigger a webhook event for testing?">
 A: You can do it through the webhook dashboard. Go to Dashboard -> Developers -> Webhooks
 </Accordion>
 
-<Accordion title="Q126: What's the difference between webhook and redirect URL?">
+<Accordion title="Q125: What's the difference between webhook and redirect URL?">
 A:
 - **Webhook URL**: Configured in dashboard. Receives POST payloads about events.
 - **Redirect URL**: Sent in the payment API request. Sends user back to your app with query params (`?status=success`).
@@ -868,11 +864,11 @@ Use webhooks to automate things like DB updates, and redirects to show thank-you
 </Tip>
 </Accordion>
 
-<Accordion title="Q127: Why didn't I receive the product id in the payment.succeeded webhook for a subscription product?">
+<Accordion title="Q126: Why didn't I receive the product id in the payment.succeeded webhook for a subscription product?">
 A: The payment.succeeded webhook event for subscription products does not include a product_id. Instead, it provides the `subscription_id` associated with the subscription, along with other relevant details.
 </Accordion>
 
-<Accordion title="Q128: How do I verify the webhooks I receive are actually from dodo payments and not from any malicious actors?">
+<Accordion title="Q127: How do I verify the webhooks I receive are actually from dodo payments and not from any malicious actors?">
   A: To verify webhook authenticity, follow these steps:
 
   1. **Check the Signature**: Each webhook includes a unique signature in the `webhook-signature` header, generated using your secret key and the payload
@@ -886,11 +882,11 @@ A: The payment.succeeded webhook event for subscription products does not includ
   </Tip>
 </Accordion>
 
-<Accordion title="Q129: Why am I receiving a subscription.renew webhook even for the first month payment?">
+<Accordion title="Q128: Why am I receiving a subscription.renew webhook even for the first month payment?">
 A: For subscriptions, `subscription.renew` will be triggered whenever the subscription amount is deducted. So yes, this is expected behavior.
 </Accordion>
 
-<Accordion title="Q130: How can I test webhooks locally?">
+<Accordion title="Q129: How can I test webhooks locally?">
 A: To test webhooks locally, you can follow these steps:
 
 1. **Use a Tunneling Tool**: Tools like [ngrok](https://ngrok.com/), [LocalTunnel](https://localtunnel.github.io/www/), or [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/) can expose your local server to the internet. This provides a public URL that Dodo Payments can use to send webhook events to your local environment.
@@ -899,7 +895,7 @@ A: To test webhooks locally, you can follow these steps:
 
 </Accordion>
 
-<Accordion title="Q131: Why is my webhook not being called after payment?">
+<Accordion title="Q130: Why is my webhook not being called after payment?">
 A: Check the following:
 - You did not confuse the webhook URL with redirect URL
 - The webhook is configured under Developers > Webhooks
@@ -909,7 +905,7 @@ A: Check the following:
 If you only see GETs with ?status=success, you are debugging the redirect URL, not the webhook.
 </Accordion>
 
-<Accordion title="Q132: Is it safe to rely on status=success in URL query params?">
+<Accordion title="Q131: Is it safe to rely on status=success in URL query params?">
 A: No. While it's a quick win, URL query params can be tampered with.
 
 If you're using redirect_url?status=success:
@@ -921,11 +917,11 @@ Treat redirects as user-facing confirmations, not proof of payment.
 </Tip>
 </Accordion>
 
-<Accordion title="Q133: Can I integrate Dodo Payments with my existing website or platform?">
+<Accordion title="Q132: Can I integrate Dodo Payments with my existing website or platform?">
 A: Yes, Dodo Payments offers **API integration** and **SDKs support** for seamless integration with your website or platform. You can find API documentation, SDK guides, and integration resources in the **Developer Section** of your dashboard.
 </Accordion>
 
-<Accordion title="Q134: Why are my webhooks always failing?">
+<Accordion title="Q133: Why are my webhooks always failing?">
   A: Common causes:
 
   - Your endpoint is unreachable or returning a non-2xx status code
@@ -937,24 +933,24 @@ A: Yes, Dodo Payments offers **API integration** and **SDKs support** for seamle
   ![Webhook failed attempts](/images/webhooks/webhook-failed.png)
 </Accordion>
 
-<Accordion title="Q135: Where do I find my API key?">
+<Accordion title="Q134: Where do I find my API key?">
   A: Go to Dashboard → Developer tab → API Keys section. Make sure you're in the correct mode (Test or Live) before copying the key.
 </Accordion>
 
-<Accordion title="Q136: What are the base URLs for the Dodo Payments API?">
+<Accordion title="Q135: What are the base URLs for the Dodo Payments API?">
   A: - **Live Mode:** https://live.dodopayments.com
 - **Test Mode:** https://test.dodopayments.com
 </Accordion>
 
 ## Testing & Local Development
 
-<Accordion title="Q137: Can I test subscriptions in Test Mode?">
+<Accordion title="Q136: Can I test subscriptions in Test Mode?">
 A: Yes — subscriptions can be tested fully in Test Mode.
 
 Just don't use real card numbers.
 </Accordion>
 
-<Accordion title="Q138: How do I switch between Test and Live Mode?">
+<Accordion title="Q137: How do I switch between Test and Live Mode?">
 A:
 - On your Dodo dashboard, look for a Test Mode toggle.
 - Switch it ON to use test API keys and simulate payments.
@@ -962,7 +958,7 @@ A:
 You'll see "Test Mode" labels on all screens. Make sure to use the corresponding API key or environment when switching.
 </Accordion>
 
-<Accordion title="Q139: Can I use real customer data in Test Mode?">
+<Accordion title="Q138: Can I use real customer data in Test Mode?">
 A: Yes, but keep in mind:
 - No real money will be transferred
 - You can simulate webhooks and flows
@@ -971,11 +967,11 @@ A: Yes, but keep in mind:
 This helps debug flows end-to-end without any financial impact.
 </Accordion>
 
-<Accordion title="Q140: Can I advance the next billing date in test mode?">
+<Accordion title="Q139: Can I advance the next billing date in test mode?">
   A: Yes. Use the Update Subscription API and set the next_billing_date field to the date you want. See the docs: https://docs.dodopayments.com/api-reference/subscriptions/patch-subscriptions#body-next-billing-date-one-of-0
 </Accordion>
 
-<Accordion title="Q141: Why don't I receive emails in Test Mode?">
+<Accordion title="Q140: Why don't I receive emails in Test Mode?">
   A: In Test Mode, emails are **not sent** to simulate a development environment without real notifications.
 
   **What this means:**
@@ -990,11 +986,11 @@ This helps debug flows end-to-end without any financial impact.
 
 ## Support & Communication
 
-<Accordion title="Q142: How do I contact support?">
+<Accordion title="Q141: How do I contact support?">
 A: You can contact our support team by sending an email to [**support@dodopayments.com**](mailto:support@dodopayments.com). We are here to assist you with any issues or questions you may have.
 </Accordion>
 
-<Accordion title="Q143: My support messages are getting no response. What should I do?">
+<Accordion title="Q142: My support messages are getting no response. What should I do?">
 A: If you've messaged in:
 - Intercom with no response
 - Discord without acknowledgement
@@ -1003,53 +999,53 @@ Then:
 - Escalate via compliance@dodopayments.com or support@dodopayments.com with subject line Urgent: No Response – [Your Email]
 </Accordion>
 
-<Accordion title="Q144: How do I unsubscribe a customer from Dodo Digest emails?">
+<Accordion title="Q143: How do I unsubscribe a customer from Dodo Digest emails?">
   A: Share the customer's email address with us via Intercom and we'll unsubscribe them from our end.
 </Accordion>
 
 ## Security & Fraud Prevention
 
-<Accordion title="Q145: How does Dodo Payments protect my business from fraud?">
+<Accordion title="Q144: How does Dodo Payments protect my business from fraud?">
 A: Dodo Payments uses **real-time fraud detection** to monitor suspicious transactions. We also comply with **PCI-DSS standards** to ensure that all payment information is encrypted and secure.
 </Accordion>
 
-<Accordion title="Q146: Is my customer data secure with Dodo Payments?">
+<Accordion title="Q145: Is my customer data secure with Dodo Payments?">
 A: Yes, Dodo Payments uses **data encryption** and **tokenization** to protect sensitive information. We ensure that customer payment data is never stored directly and remains secure during transactions.
 </Accordion>
 
-<Accordion title="Q147: I found a security vulnerability in Dodo Payments. How should I report it?">
+<Accordion title="Q146: I found a security vulnerability in Dodo Payments. How should I report it?">
 A: Please report any discovered vulnerabilities directly to our security team at pt-team@dodopayments.com
 </Accordion>
 
-<Accordion title="Q148: Does Dodo Payments offer bug bounties?">
+<Accordion title="Q147: Does Dodo Payments offer bug bounties?">
 A: We currently do not offer monetary bounties, but we do provide Dodo Payments merchandise as a token of appreciation.
 </Accordion>
 
-<Accordion title="Q149: How are customers protected from fraud on Dodo Payments?">
+<Accordion title="Q148: How are customers protected from fraud on Dodo Payments?">
   A: Dodo Payments uses real-time fraud detection to analyze and block suspicious transactions before they occur. All payments are also protected through standard card network safeguards — customers can raise disputes or chargebacks for unauthorized charges. We are PCI compliant, ensuring all payment data meets the highest security standards.
 </Accordion>
 
 ## Payments Failures
 
-<Accordion title="Q150: Why is my payment status showing 'Not Initiated'?">
+<Accordion title="Q149: Why is my payment status showing 'Not Initiated'?">
   A: This means the payment link was created, but the user never opened the payment page or attempted the payment.
 </Accordion>
 
-<Accordion title="Q151: Why is my payment status showing 'Requires Payment Method'?">
+<Accordion title="Q150: Why is my payment status showing 'Requires Payment Method'?">
   A: This means the user opened the payment page and entered customer details but exited before adding card or payment details.
 </Accordion>
 
 
-<Accordion title="Q152: Why am I getting an 'Invalid authorization details' error?">
+<Accordion title="Q151: Why am I getting an 'Invalid authorization details' error?">
   A: This usually happens when the 3D Secure (3DS) authentication fails or is not completed by the user.
 </Accordion>
 
 
-<Accordion title="Q153: Why am I getting an 'Authentication failure' error for payments?">
+<Accordion title="Q152: Why am I getting an 'Authentication failure' error for payments?">
   A: The payment failed due to an authentication error. Please check with your bank regarding this issue. Unfortunately, there is nothing further we can do from our side. We recommend trying a different card or a different payment method.
 </Accordion>
 
-<Accordion title="Q154: I'm seeing a 500 internal_error (&quot;Internal Server Error&quot;) in test mode. How do I fix it?">
+<Accordion title="Q153: I'm seeing a 500 internal_error (&quot;Internal Server Error&quot;) in test mode. How do I fix it?">
   A: This typically happens when the test card does not match the billing country:
 
   - **US billing country** → Use a US test card
@@ -1058,7 +1054,7 @@ A: We currently do not offer monetary bounties, but we do provide Dodo Payments 
   Refer to the [test card numbers documentation](https://docs.dodopayments.com/miscellaneous/testing-process#test-card-numbers).
 </Accordion>
 
-<Accordion title="Q155: Why am I getting payment_method_unsupported (&quot;mode not enabled for merchant&quot;) in test mode?">
+<Accordion title="Q154: Why am I getting payment_method_unsupported (&quot;mode not enabled for merchant&quot;) in test mode?">
   A: The selected payment method is not enabled for your merchant account. Ensure you are using the correct test card for your billing country:
 
   - **US billing country** → Use a US test card
@@ -1067,21 +1063,21 @@ A: We currently do not offer monetary bounties, but we do provide Dodo Payments 
   Refer to the [test card numbers documentation](https://docs.dodopayments.com/miscellaneous/testing-process#test-card-numbers).
 </Accordion>
 
-<Accordion title="Q156: What does the requires_customer_action status mean?">
+<Accordion title="Q155: What does the requires_customer_action status mean?">
   A: The payment requires additional action from the customer — such as 3D Secure authentication, OTP verification, or UPI approval. The customer must complete the required action before the payment can be processed.
 </Accordion>
 
-<Accordion title="Q157: Why am I getting a SUBSCRIPTION_NOT_ACTIVE error?">
+<Accordion title="Q156: Why am I getting a SUBSCRIPTION_NOT_ACTIVE error?">
   A: This error occurs when the customer has cancelled the mandate (recurring payment authorization) from their UPI app. The subscription can no longer process payments because the underlying mandate has been revoked by the customer.
 </Accordion>
 
-<Accordion title="Q158: Why am I getting a payment failure with unknown_error?">
+<Accordion title="Q157: Why am I getting a payment failure with unknown_error?">
   A: Your payment failed with error code `unknown_error`. The payment was initially processed, but your bank later reversed the transaction and refunded the amount, so it was marked as failed. This issue is not from our side.
 
   Please try making the payment again. If it fails again, try using a different card or payment method. You may also contact your bank for further clarification.
 </Accordion>
 
-<Accordion title="Q159: I'm getting: &quot;You must provide a mandate for off-session card payments&quot;">
+<Accordion title="Q158: I'm getting: &quot;You must provide a mandate for off-session card payments&quot;">
   A: It means:
   - An Indian Card is used to make the payment but the billing country is not set as IN.
   - You likely passed an incorrect billing country.
@@ -1089,28 +1085,28 @@ A: We currently do not offer monetary bounties, but we do provide Dodo Payments 
 
 ## Developer & Technical Integration
 
-<Accordion title="Q160: Is the customer portal tied to a specific customer?">
+<Accordion title="Q159: Is the customer portal tied to a specific customer?">
   A: Yes. The portal is customer-specific. You can either send a magic link for a specific customer (one-time, expires in 24 hours) or use the static email login where the customer enters their purchase email to get a secure link. When you create a portal session via API (customerPortal.create('cus_123')), it's bound to that customer.
 </Accordion>
 
-<Accordion title="Q161: Can I use Laravel with Dodo Payments?">
+<Accordion title="Q160: Can I use Laravel with Dodo Payments?">
   A: Yes, Laravel is supported. See the PHP/Laravel SDK docs: https://docs.dodopayments.com/developer-resources/sdks/php#laravel
 </Accordion>
 
-<Accordion title="Q162: Does Dodo Payments support WHMCS?">
+<Accordion title="Q161: Does Dodo Payments support WHMCS?">
   A: WHMCS is not officially supported. You can either build a custom payment module using our API (payments + webhooks), or use Dodo checkout links in invoices as a temporary workaround.
 </Accordion>
 
-<Accordion title="Q163: Can I integrate Dodo Payments in an Android or mobile app?">
+<Accordion title="Q162: Can I integrate Dodo Payments in an Android or mobile app?">
   A: Yes. Refer to the mobile integration guide: https://docs.dodopayments.com/developer-resources/mobile-integration#mobile-integration-guide
 
 You can also use the Sentra VS Code extension for integration assistance: https://docs.dodopayments.com/developer-resources/sentra#sentra
 </Accordion>
 
-<Accordion title="Q164: How do I find my live publishable key (pk_live_...)?">
+<Accordion title="Q163: How do I find my live publishable key (pk_live_...)?">
   A: Switch to Live Mode in the dashboard. Go to the Developer section → click Other → you'll see the Publishable Key. Click View to reveal it.
 </Accordion>
 
-<Accordion title="Q165: Does Dodo Payments support WooCommerce blocks (WordPress block editor)?">
+<Accordion title="Q164: Does Dodo Payments support WooCommerce blocks (WordPress block editor)?">
   A: Not currently. The WooCommerce plugin is open source — if you'd like this feature, you're welcome to raise a pull request to implement it.
 </Accordion>

--- a/miscellaneous/testing-process.mdx
+++ b/miscellaneous/testing-process.mdx
@@ -60,13 +60,57 @@ Use these card numbers to simulate successful and declined payments across diffe
 | India | Visa | `4706131211212123` | Generic decline |
 | India | Mastercard | `5105105105105100` | Generic decline |
 </Tab>
+
+<Tab title="Subscription Failure Testing (Renewal/Upgrade/Downgrade)">
+| Card Number | Expiry | CVC |
+| :---------- | :----- | :-- |
+| `4000 0000 0000 0341` | 12/34 | 123 |
+
+Use this card to test subscription Failure renewal, upgrade, and downgrade scenarios.
+</Tab>
 </Tabs>
 
 <Info>
-For all test cards, use expiry date **06/32** and CVV **123**.
+For all test cards, use expiry date **06/32** (or **12/34**) and CVV **123**.
 </Info>
 
-For more details on card testing, including 3D Secure and saved payment methods, see the [Cards](/features/payment-methods/cards) page.
+### How to Test Renewal Failure
+
+<Steps>
+<Step title="Create a test subscription">
+Create a subscription with your test API keys using a **success** test card (for example, `4242 4242 4242 4242`). The initial charge should succeed and the subscription should become active.
+</Step>
+
+<Step title="Swap in the failure card via Customer Portal">
+Open the [Customer Portal](/features/customer-portal), find the subscription you just created, and click **Update Payment Method**. Enter the failure test card `4000 0000 0000 0341` (Expiry: `12/34`, CVC: `123`) and save it as the subscription's payment method.
+</Step>
+
+<Step title="Advance the next billing date (optional)">
+To trigger renewal immediately instead of waiting for the natural billing cycle, use the Update Subscription API to set `next_billing_date` to the current UTC time. The value must be an ISO 8601 / RFC 3339 UTC timestamp (the `Z` suffix is required).
+
+```http
+PATCH /subscriptions/{subscription_id}
+{
+  "next_billing_date": "2026-05-03T00:00:00Z"
+}
+```
+
+See the [Update Subscription API reference](/api-reference/subscriptions/patch-subscriptions#body-next-billing-date-one-of-0) for details.
+</Step>
+
+<Step title="Verify the failure">
+On the next billing attempt:
+
+- The renewal charge declines on the failure card
+- The subscription moves to **On-Hold** status
+- A `payment.failed` webhook event is delivered
+- The customer can return to the Customer Portal to update the payment method and retry
+</Step>
+</Steps>
+
+<Warning>
+This card is specifically for testing renewal failures. The charge will decline on the next billing date, allowing you to test payment retry logic, customer notifications, and failure handling.
+</Warning>
 
 ## Test UPI
 


### PR DESCRIPTION
## Summary

- **`miscellaneous/testing-process.mdx`** — Adds a `How to Test Renewal Failure` walkthrough using the failure test card `4000 0000 0000 0341`:
  1. Create the subscription with a **success** card so it activates.
  2. Open the **Customer Portal**, find the subscription, click **Update Payment Method**, and swap in the failure card.
  3. Optionally advance `next_billing_date` via the Update Subscription API (clarified the value is an ISO 8601 / RFC 3339 UTC timestamp with the `Z` suffix).
  4. Verify the renewal declines, the subscription moves to **On-Hold**, and a `payment.failed` webhook fires.
- Adds a **Subscription Failure Testing** tab in the test cards table that documents the `4000 0000 0000 0341` card.
- Updates the global expiry note to mention `12/34` as a valid expiry alongside `06/32`.
- Drops the trailing "see the Cards page" line that used to sit below the cards table.

- **`miscellaneous/faq.mdx`** — Removes **Q23: "Can I remove or delete a brand from my account?"** which contradicted the brand management documentation, and renumbers `Q24..Q165` down to `Q23..Q164` so the sequence stays contiguous (164 FAQs total, no gaps).

## Why

- The renewal failure flow was previously undocumented even though the failure card existed in the cards table — merchants had no guided way to reproduce the On-Hold transition or `payment.failed` webhook.
- The Step 3 example for `next_billing_date` was a plain date string (`"2026-04-27"`), which doesn't match the API's `format: date-time` requirement; the new example uses a valid UTC timestamp.
- Q23 in the FAQ stated brands cannot be deleted, but it was a duplicate/contradictory entry; removing it and renumbering keeps the FAQ list clean.

## Verification

- Verified locally with `mintlify dev` — `/miscellaneous/testing-process` and `/miscellaneous/faq` render correctly.
- FAQ Accordion structure validated: 164 opens / 164 closes, contiguous Q1..Q164, no orphaned references in other docs.
- Internal links use relative paths (e.g. `/api-reference/subscriptions/patch-subscriptions#...`, `/features/customer-portal`) consistent with the rest of the file.