### PR TITLE
docs(customer-portal): remove embedded contexts forceLanguage bullet

### DIFF
--- a/features/customer-portal.mdx
+++ b/features/customer-portal.mdx
@@ -161,7 +161,6 @@ The Customer Portal is available in **21 languages**, so your customers can mana
 - **Automatic detection**: On first visit, the portal detects the customer's preferred language from their browser settings and loads the matching translation if available. English is used as the fallback.
 - **Manual override**: Customers can change the active language at any time from the language selector in the portal header (available on both desktop and mobile).
 - **Persisted preference**: The selected language is stored in the `NEXT_LOCALE` cookie (valid for 1 year) so the portal remembers the choice across sessions.
-- **Embedded contexts**: When the portal is embedded in an iframe and cookies are blocked, the portal falls back to a `forceLanguage` URL parameter so the chosen language is still respected.
 
 ### Supported languages
 


### PR DESCRIPTION
## Summary
- Removes the **Embedded contexts** bullet from the Language preferences section in `features/customer-portal.mdx`.
- The bullet referenced an iframe `forceLanguage` URL parameter fallback that is no longer accurate for the customer portal documentation.

## Scope
- Single file change: `features/customer-portal.mdx` (1 line deleted)
- Translated locale files are intentionally not touched in this PR; they will be picked up by the existing translation sync workflow.