### PR TITLE
docs(merchant-acceptance): update accepted countries list and remove accepted territories section

### DIFF
--- a/miscellaneous/merchant-acceptance.mdx
+++ b/miscellaneous/merchant-acceptance.mdx
@@ -108,10 +108,10 @@ While we aim to support a wide range of businesses, approval isn't guaranteed. I
 
 If your product operates near the edge of these categories, we encourage you to reach out before applying. We may still be able to support you, especially if you're transparent about your model, actively mitigate risks, and are willing to work within platform guidelines. You can reach out to compliance@dodopayments.com to check if you qualify.
 
-## Accepted Countries
+## Accepted Countries & Territories
 
 <AccordionGroup>
-<Accordion title="Accepted countries">
+<Accordion title="Accepted Countries & Territories">
 
 1. Afghanistan
 2. Albania
@@ -134,177 +134,168 @@ If your product operates near the edge of these categories, we encourage you to 
 19. Bermuda
 20. Bhutan
 21. Bolivia
-22. Bonaire, Sint Eustatius and Saba
-23. Bosnia and Herzegovina
-24. Botswana
-25. Brazil
-26. British Virgin Islands
-27. Brunei Darussalam
-28. Bulgaria
-29. Burkina Faso
-30. Burundi
-31. Cabo Verde
-32. Cambodia
-33. Canada
-34. Cayman Islands
-35. Chad
-36. Chile
-37. China
-38. Colombia
-39. Comoros
-40. Cook Islands
-41. Costa Rica
-42. Croatia
-43. Curacao
-44. Cyprus
-45. Czech Republic
-46. Denmark
-47. Djibouti
-48. Dominica
-49. Dominican Republic
-50. Ecuador
-51. Egypt
-52. El Salvador
-53. Estonia
-54. Eswatini
-55. Ethiopia
-56. Falkland Islands
-57. Faroe Islands
-58. Fiji
-59. Finland
-60. France
-61. French Guiana
-62. French Polynesia
-63. Gabon
-64. Gambia
-65. Georgia
-66. Germany
-67. Ghana
-68. Gibraltar
-69. Greece
-70. Greenland
-71. Grenada
-72. Guadeloupe
-73. Guam
-74. Guatemala
-75. Guernsey
-76. Guinea
-77. Guinea-Bissau
-78. Guyana
-79. Honduras
-80. Hong Kong
-81. Hungary
-82. Iceland
-83. India
-84. Indonesia
-85. Ireland
-86. Isle of Man
-87. Israel
-88. Italy
-89. Jamaica
-90. Japan
-91. Jersey
-92. Jordan
-93. Kazakhstan
-94. Kiribati
-95. Kosovo
-96. Kyrgyzstan
-97. Latvia
-98. Lesotho
-99. Liberia
-100. Liechtenstein
-101. Lithuania
-102. Luxembourg
-103. Macao
-104. Madagascar
-105. Malawi
-106. Malaysia
-107. Maldives
-108. Mali
-109. Malta
-110. Martinique
-111. Mauritania
-112. Mauritius
-113. Mayotte
-114. Mexico
-115. Moldova
-116. Monaco
-117. Mongolia
-118. Montenegro
-119. Montserrat
-120. Morocco
-121. Mozambique
-122. Namibia
-123. Nepal
-124. Netherlands
-125. New Caledonia
-126. New Zealand
-127. Niger
-128. Nigeria
-129. North Macedonia
-130. Norway
-131. Oman
-132. Palau
-133. Panama
-134. Paraguay
-135. Peru
-136. Philippines
-137. Poland
-138. Portugal
-139. Puerto Rico
-140. Qatar
-141. Republic of Congo
-142. Republic of Korea
-143. Reunion
-144. Romania
-145. Rwanda
-146. Saint Kitts and Nevis
-147. Saint Lucia
-148. Saint Martin
-149. Saint Pierre and Miquelon
-150. Saint Vincent and the Grenadines
-151. Samoa
-152. San Marino
-153. Sao Tome and Principe
-154. Saudi Arabia
-155. Senegal
-156. Serbia
-157. Seychelles
-158. Sierra Leone
-159. Singapore
-160. Sint Maarten
-161. Slovakia
-162. Slovenia
-163. Solomon Islands
-164. South Africa
-165. Spain
-166. Sri Lanka
-167. Suriname
-168. Sweden
-169. Switzerland
-170. Taiwan
-171. Tajikistan
-172. Tanzania
-173. Thailand
-174. Timor-Leste
-175. Togo
-176. Tonga
-177. Trinidad and Tobago
-178. Tunisia
-179. Türkiye
-180. Turkmenistan
-181. Turks and Caicos Islands
-182. Uganda
-183. United Arab Emirates
-184. United Kingdom
-185. United States
-186. Uruguay
-187. Uzbekistan
-188. Vanuatu
-189. Vietnam
-190. Virgin Islands
-191. Zambia
-192. Zimbabwe
+22. Bosnia and Herzegovina
+23. Botswana
+24. Brazil
+25. British Virgin Islands
+26. Brunei Darussalam
+27. Bulgaria
+28. Burkina Faso
+29. Burundi
+30. Cabo Verde
+31. Cambodia
+32. Canada
+33. Cayman Islands
+34. Chad
+35. Chile
+36. China
+37. Colombia
+38. Comoros
+39. Cook Islands
+40. Costa Rica
+41. Croatia
+42. Curacao
+43. Cyprus
+44. Czech Republic
+45. Denmark
+46. Djibouti
+47. Dominica
+48. Dominican Republic
+49. Ecuador
+50. Egypt
+51. El Salvador
+52. Estonia
+53. Eswatini
+54. Ethiopia
+55. Falkland Islands
+56. Faroe Islands
+57. Fiji
+58. Finland
+59. France
+60. French Polynesia
+61. Gabon
+62. Gambia
+63. Georgia
+64. Germany
+65. Ghana
+66. Gibraltar
+67. Greece
+68. Greenland
+69. Grenada
+70. Guam
+71. Guatemala
+72. Guernsey
+73. Guinea
+74. Guinea-Bissau
+75. Guyana
+76. Honduras
+77. Hungary
+78. Iceland
+79. India
+80. Indonesia
+81. Ireland
+82. Isle of Man
+83. Israel
+84. Italy
+85. Jamaica
+86. Japan
+87. Jersey
+88. Jordan
+89. Kazakhstan
+90. Kiribati
+91. Kyrgyzstan
+92. Latvia
+93. Lesotho
+94. Liberia
+95. Liechtenstein
+96. Lithuania
+97. Luxembourg
+98. Madagascar
+99. Malawi
+100. Malaysia
+101. Maldives
+102. Mali
+103. Malta
+104. Mauritania
+105. Mauritius
+106. Mexico
+107. Moldova
+108. Monaco
+109. Mongolia
+110. Montenegro
+111. Montserrat
+112. Morocco
+113. Mozambique
+114. Namibia
+115. Nepal
+116. Netherlands
+117. New Caledonia
+118. New Zealand
+119. Niger
+120. Nigeria
+121. North Macedonia
+122. Norway
+123. Oman
+124. Palau
+125. Panama
+126. Paraguay
+127. Peru
+128. Philippines
+129. Poland
+130. Portugal
+131. Puerto Rico
+132. Qatar
+133. Republic of Congo
+134. Republic of Korea
+135. Romania
+136. Rwanda
+137. Saint Kitts and Nevis
+138. Saint Lucia
+139. Saint Martin
+140. Saint Pierre and Miquelon
+141. Saint Vincent and the Grenadines
+142. Samoa
+143. San Marino
+144. Sao Tome and Principe
+145. Saudi Arabia
+146. Senegal
+147. Serbia
+148. Seychelles
+149. Sierra Leone
+150. Singapore
+151. Sint Maarten
+152. Slovakia
+153. Slovenia
+154. Solomon Islands
+155. South Africa
+156. Spain
+157. Sri Lanka
+158. Suriname
+159. Sweden
+160. Switzerland
+161. Tajikistan
+162. Tanzania
+163. Thailand
+164. Timor-Leste
+165. Togo
+166. Tonga
+167. Trinidad and Tobago
+168. Tunisia
+169. Türkiye
+170. Turkmenistan
+171. Turks and Caicos Islands
+172. Uganda
+173. United Arab Emirates
+174. United Kingdom
+175. United States
+176. Uruguay
+177. Uzbekistan
+178. Vanuatu
+179. Vietnam
+180. Virgin Islands
+181. Wallis and Futuna
+182. Zambia
+183. Zimbabwe
 
 </Accordion>
 </AccordionGroup>
@@ -312,41 +303,6 @@ If your product operates near the edge of these categories, we encourage you to 
 <Note>
 This policy applies to all country designations made on or after March 23, 2026. Merchants receiving services in countries supported prior to this date will not be affected, unless the relevant country is subject to active sanctions or regulatory restrictions. In such cases, Dodo Payments reserves the right to discontinue support.
 </Note>
-
-## Accepted Territories
-
-<AccordionGroup>
-<Accordion title="Accepted territories">
-
-1. Anguilla
-2. Aruba
-3. Bermuda
-4. British Virgin Islands
-5. Cayman Islands
-6. Cook Islands
-7. Curacao
-8. Falkland Islands
-9. Faroe Islands
-10. French Polynesia
-11. Gibraltar
-12. Greenland
-13. Guam
-14. Guernsey
-15. Isle of Man
-16. Jersey
-17. Montserrat
-18. New Caledonia
-19. Palau
-20. Puerto Rico
-21. Saint Martin
-22. Saint Pierre and Miquelon
-23. Sint Maarten
-24. Turks and Caicos Islands
-25. US Virgin Islands
-26. Wallis and Futuna
-
-</Accordion>
-</AccordionGroup>
 
 <Note>
 This list is regularly updated to reflect FATF, OFAC, UN, and EU AML/CFT directives. All merchants are responsible for ensuring ongoing compliance.


### PR DESCRIPTION
## Summary
- Updates the **Accepted Countries** list in `miscellaneous/merchant-acceptance.mdx` to the latest authoritative list (183 entries).
- Removes the entire **Accepted Territories** section (heading, accordion, and 26-territory list), since accepted territories are no longer maintained as a separate list.

## Notable changes to the country list
- Removed: Bonaire/Sint Eustatius and Saba, French Guiana, Guadeloupe, Hong Kong, Kosovo, Macao, Martinique, Mayotte, Reunion, Taiwan
- Added: Wallis and Futuna
- List renumbered 1–183

## Scope
- Single file: `miscellaneous/merchant-acceptance.mdx` (164 insertions, 208 deletions)
- Translated locale files are intentionally not touched in this PR; they will be picked up by the existing translation sync workflow.