### PR TITLE
docs(merchant-acceptance): add Hong Kong and Taiwan to accepted countries

### DIFF
--- a/miscellaneous/merchant-acceptance.mdx
+++ b/miscellaneous/merchant-acceptance.mdx
@@ -189,113 +189,115 @@ If your product operates near the edge of these categories, we encourage you to 
 74. Guinea-Bissau
 75. Guyana
 76. Honduras
-77. Hungary
-78. Iceland
-79. India
-80. Indonesia
-81. Ireland
-82. Isle of Man
-83. Israel
-84. Italy
-85. Jamaica
-86. Japan
-87. Jersey
-88. Jordan
-89. Kazakhstan
-90. Kiribati
-91. Kyrgyzstan
-92. Latvia
-93. Lesotho
-94. Liberia
-95. Liechtenstein
-96. Lithuania
-97. Luxembourg
-98. Madagascar
-99. Malawi
-100. Malaysia
-101. Maldives
-102. Mali
-103. Malta
-104. Mauritania
-105. Mauritius
-106. Mexico
-107. Moldova
-108. Monaco
-109. Mongolia
-110. Montenegro
-111. Montserrat
-112. Morocco
-113. Mozambique
-114. Namibia
-115. Nepal
-116. Netherlands
-117. New Caledonia
-118. New Zealand
-119. Niger
-120. Nigeria
-121. North Macedonia
-122. Norway
-123. Oman
-124. Palau
-125. Panama
-126. Paraguay
-127. Peru
-128. Philippines
-129. Poland
-130. Portugal
-131. Puerto Rico
-132. Qatar
-133. Republic of Congo
-134. Republic of Korea
-135. Romania
-136. Rwanda
-137. Saint Kitts and Nevis
-138. Saint Lucia
-139. Saint Martin
-140. Saint Pierre and Miquelon
-141. Saint Vincent and the Grenadines
-142. Samoa
-143. San Marino
-144. Sao Tome and Principe
-145. Saudi Arabia
-146. Senegal
-147. Serbia
-148. Seychelles
-149. Sierra Leone
-150. Singapore
-151. Sint Maarten
-152. Slovakia
-153. Slovenia
-154. Solomon Islands
-155. South Africa
-156. Spain
-157. Sri Lanka
-158. Suriname
-159. Sweden
-160. Switzerland
-161. Tajikistan
-162. Tanzania
-163. Thailand
-164. Timor-Leste
-165. Togo
-166. Tonga
-167. Trinidad and Tobago
-168. Tunisia
-169. Türkiye
-170. Turkmenistan
-171. Turks and Caicos Islands
-172. Uganda
-173. United Arab Emirates
-174. United Kingdom
-175. United States
-176. Uruguay
-177. Uzbekistan
-178. Vanuatu
-179. Vietnam
-180. Virgin Islands
-181. Wallis and Futuna
-182. Zambia
-183. Zimbabwe
+77. Hong Kong
+78. Hungary
+79. Iceland
+80. India
+81. Indonesia
+82. Ireland
+83. Isle of Man
+84. Israel
+85. Italy
+86. Jamaica
+87. Japan
+88. Jersey
+89. Jordan
+90. Kazakhstan
+91. Kiribati
+92. Kyrgyzstan
+93. Latvia
+94. Lesotho
+95. Liberia
+96. Liechtenstein
+97. Lithuania
+98. Luxembourg
+99. Madagascar
+100. Malawi
+101. Malaysia
+102. Maldives
+103. Mali
+104. Malta
+105. Mauritania
+106. Mauritius
+107. Mexico
+108. Moldova
+109. Monaco
+110. Mongolia
+111. Montenegro
+112. Montserrat
+113. Morocco
+114. Mozambique
+115. Namibia
+116. Nepal
+117. Netherlands
+118. New Caledonia
+119. New Zealand
+120. Niger
+121. Nigeria
+122. North Macedonia
+123. Norway
+124. Oman
+125. Palau
+126. Panama
+127. Paraguay
+128. Peru
+129. Philippines
+130. Poland
+131. Portugal
+132. Puerto Rico
+133. Qatar
+134. Republic of Congo
+135. Republic of Korea
+136. Romania
+137. Rwanda
+138. Saint Kitts and Nevis
+139. Saint Lucia
+140. Saint Martin
+141. Saint Pierre and Miquelon
+142. Saint Vincent and the Grenadines
+143. Samoa
+144. San Marino
+145. Sao Tome and Principe
+146. Saudi Arabia
+147. Senegal
+148. Serbia
+149. Seychelles
+150. Sierra Leone
+151. Singapore
+152. Sint Maarten
+153. Slovakia
+154. Slovenia
+155. Solomon Islands
+156. South Africa
+157. Spain
+158. Sri Lanka
+159. Suriname
+160. Sweden
+161. Switzerland
+162. Taiwan
+163. Tajikistan
+164. Tanzania
+165. Thailand
+166. Timor-Leste
+167. Togo
+168. Tonga
+169. Trinidad and Tobago
+170. Tunisia
+171. Türkiye
+172. Turkmenistan
+173. Turks and Caicos Islands
+174. Uganda
+175. United Arab Emirates
+176. United Kingdom
+177. United States
+178. Uruguay
+179. Uzbekistan
+180. Vanuatu
+181. Vietnam
+182. Virgin Islands
+183. Wallis and Futuna
+184. Zambia
+185. Zimbabwe
 
 </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Adds **Hong Kong** and **Taiwan** to the Accepted Countries & Territories list in `miscellaneous/merchant-acceptance.mdx`.
- List is renumbered (1–185) and remains in strict alphabetical order.

## Insertion points
- **Hong Kong** at position 77 (between Honduras and Hungary)
- **Taiwan** at position 162 (between Switzerland and Tajikistan)

## Scope
- Single file: `miscellaneous/merchant-acceptance.mdx`
- Translated locale files are intentionally not touched in this PR; they will be picked up by the existing translation sync workflow.