### PR TITLE
docs: add fulfillment channels & access delivery provisions

### DIFF
--- a/miscellaneous/merchant-acceptance.mdx
+++ b/miscellaneous/merchant-acceptance.mdx
@@ -108,6 +108,18 @@ While we aim to support a wide range of businesses, approval isn't guaranteed. I
 
 If your product operates near the edge of these categories, we encourage you to reach out before applying. We may still be able to support you, especially if you're transparent about your model, actively mitigate risks, and are willing to work within platform guidelines. You can reach out to compliance@dodopayments.com to check if you qualify.
 
+## Fulfillment Channels & Access Delivery
+
+Some merchants use Dodo Payments to deliver access on purchase — for example, a license key, a downloadable file bundle, a Discord role, GitHub collaborator access, a Telegram chat or channel invite, a Notion template, or a Framer remix link. Where Dodo Payments fulfils that delivery, the standards in this policy apply both to what is sold on the storefront and to what is actually delivered through the channel.
+
+In particular:
+
+- Communities, files, repositories, templates, and other resources made available to customers through a Dodo-fulfilled channel must align with the merchant's disclosed product and with this policy.
+- A community, file bundle, repository, or template that delivers material misaligned with the disclosed product, or that contains content that would itself be ineligible under this policy (for example, adult content, piracy or unauthorised resale, deceptive claims, unlicensed financial advice, or weapons-related content), is treated as a policy breach regardless of how the storefront is positioned.
+- Continued use of these channels to deliver access is conditioned on ongoing alignment with this policy. Material drift between the advertised product and the gated content may result in account review, restriction, or closure under our enforcement process.
+
+This applies whether the channel is created and operated by the merchant or by a third party.
+
 ## Accepted Countries & Territories
 
 <AccordionGroup>
@@ -345,6 +357,7 @@ The following may trigger investigation or enforcement:
 8. Requests by legal authorities upon receipt of relevant legal order.
 9. Reports of fraudulent activities flagged by our regulatory and compliance partners, and customer reports.
 10. Any other material breaches of our platform policies or violations of law as applicable
+11. Delivering, through a Dodo-fulfilled access channel (for example, a license key, downloadable file, Discord, Telegram, GitHub, Notion, or Framer integration), content or material that is misaligned with the disclosed product or that is otherwise ineligible under this policy.
 
 ### Appeals & Resolution
 

--- a/miscellaneous/review-monitoring-policy.mdx
+++ b/miscellaneous/review-monitoring-policy.mdx
@@ -22,6 +22,7 @@ We combine automated checks with human review to maintain oversight of business 
 3. Compliance with card network rules, sanctions, and applicable laws
 4. Customer experience signals such as refunds and disputes
 5. Use of approved brands, domains, and product lines
+6. Where merchants use Dodo Payments to deliver access on purchase — for example, via license keys, downloadable files, or invites to Discord, Telegram, GitHub, Notion, or Framer — alignment between the disclosed product and what is actually delivered through these channels.
 
 ## When Reviews Occur
 
@@ -29,7 +30,7 @@ Reviews take place at key points in the lifecycle:
 
 1. **Activation & First Transaction** – to confirm that products and checkout experiences match what was disclosed.
 2. **Before First Payout** – to complete compliance checks and validate fulfillment.
-3. **Ongoing Triggers** – when significant changes occur, such as new domains, product shifts, unusual transaction patterns, or rising disputes / refunds.
+3. **Ongoing Triggers** – when significant changes occur, such as new domains, product shifts, addition or material change to fulfillment channels (such as Discord, Telegram, GitHub, Notion, or Framer integrations), unusual transaction patterns, or rising disputes / refunds.
 4. **Periodic Reviews** – regular monitoring to help ensure continued compliance.
 
 ## Outcomes of Reviews
@@ -43,6 +44,20 @@ Following a review, possible outcomes include:
 ## Customer Protection
 
 We take customer complaints, fraud alerts, and refund requests seriously. In such cases, we may contact both the customer and your business. If we don’t receive a response within reasonable timelines, refunds may be processed automatically and your account may be restricted or closed.
+
+## Fulfillment Channel Checks
+
+Some merchants use Dodo Payments to provision access to communities, files, repositories, templates, or other resources after purchase. To verify that the product disclosed at onboarding remains aligned with what is actually delivered, we may carry out periodic or for-cause checks of these channels. Checks are scoped to compliance verification.
+
+Depending on the situation, a check may include:
+
+- Reviewing publicly visible information about the community, repository, or template.
+- Where the channel is private, requesting access for the limited purpose of confirming alignment with this policy and the Merchant Acceptance Policy.
+- Reviewing samples of content or materials made available to customers through the channel.
+
+These checks are scoped to verifying compliance. We do not monitor individual customers or their messages, do not retain personal data observed in these channels beyond what is necessary to record a compliance finding, and do not act as a content moderator on behalf of the merchant. Where access is required and is not provided within reasonable timelines, the matter is treated as unresolved under our enforcement process.
+
+Fulfillment channel checks are one input to our broader review program; they do not displace the customer protection, transparency, or enforcement provisions in this policy.
 
 ## Transparency & Communication
 


### PR DESCRIPTION
## Summary

Updates the **Merchant Acceptance Policy** and **Review & Monitoring Policy** to formally cover scenarios where Dodo Payments fulfils access delivery on purchase — e.g., license keys, downloadable file bundles, or invites to Discord, Telegram, GitHub, Notion, and Framer.

## Changes

### Merchant Acceptance Policy (\`miscellaneous/merchant-acceptance.mdx\`)
- New subsection **Fulfillment Channels & Access Delivery** inserted between *Businesses We Might Support* and *Accepted Countries & Territories*, clarifying that policy standards apply to both the storefront and the gated content delivered through Dodo-fulfilled channels.
- New item **#11** in *Examples of Policy Breach* covering content delivered via Dodo-fulfilled access channels that is misaligned with the disclosed product or otherwise ineligible.

### Review & Monitoring Policy (\`miscellaneous/review-monitoring-policy.mdx\`)
- New item **#6** in *Monitoring Approach* covering alignment between disclosed product and what is delivered through fulfillment channels.
- Updated **Ongoing Triggers** in *When Reviews Occur* to include addition or material change to fulfillment channels (Discord, Telegram, GitHub, Notion, Framer).
- New subsection **Fulfillment Channel Checks** between *Customer Protection* and *Transparency & Communication* describing scope, methods, and privacy limits of compliance checks on these channels.

## Notes
- Translated files under \`/{ar,cn,de,es,fr,hi,id,it,ja,ko,pt-BR,sv,vi}/miscellaneous/\` are intentionally **not modified** in this PR per request.