### PR TITLE
docs: update country coverage from 150+ to 190+

### DIFF
--- a/features/mor-vs-pg.mdx
+++ b/features/mor-vs-pg.mdx
@@ -103,7 +103,7 @@ Dodo Payments offers:
 - Real-time FX and multi-currency support
 - Access to 30+ payment methods
 - Seat-based billing, subscriptions, and one-time payments
-- Automated tax handling in 150+ countries
+- Automated tax handling in 190+ countries
 - Built-in fraud prevention and PCI compliance
 
 Whether you're a solo founder or a scaling SaaS team, Dodo simplifies the complexities of selling globally.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -34,7 +34,7 @@ Dodo Payments is the **all-in-one engine** to launch, scale, and monetize worldw
 </Card>
 
 <Card title="Global Merchant of Record" icon="globe">
-  Go global without complexity: built-in coverage in 150+ countries, 80+ currencies, and 30+ payment methods
+  Go global without complexity: built-in coverage in 190+ countries, 80+ currencies, and 30+ payment methods
 </Card>
 
 <Card title="Developer-First & No-Code" icon="code">


### PR DESCRIPTION
## Summary
- Dodo Payments now supports 190+ countries; updated outdated marketing claims that still said 150+.
- Updated English source files only — translated locale files (es/, fr/, de/, it/, ja/, ko/, cn/, ar/, hi/, id/, pt-BR/, sv/, vi/) intentionally left untouched as per request (translations are handled separately).
- Historical changelog entry (`changelog/v0.20.1.mdx`) preserved as-is since it documents the state at that release.

## Files Changed
- `introduction.mdx` — Global MoR card: "150+ countries" → "190+ countries"
- `features/mor-vs-pg.mdx` — Automated tax handling: "150+ countries" → "190+ countries"