### PR TITLE
docs(sdks/java): fix outdated Handle Subscriptions sample (closes #260)

### DIFF
--- a/developer-resources/sdks/java.mdx
+++ b/developer-resources/sdks/java.mdx
@@ -17,7 +17,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
   <groupId>com.dodopayments.api</groupId>
   <artifactId>dodo-payments-java</artifactId>
-  <version>1.86.3</version>
+  <version>1.97.1</version>
 </dependency>
 ```
 
@@ -26,7 +26,7 @@ Add the dependency to your `pom.xml`:
 Add the dependency to your `build.gradle`:
 
 ```kotlin build.gradle.kts
-implementation("com.dodopayments.api:dodo-payments-java:1.86.3")
+implementation("com.dodopayments.api:dodo-payments-java:1.97.1")
 ```
 
 <Tip>
@@ -176,25 +176,53 @@ System.out.println("Customer: " + retrieved.name() + " (" + retrieved.email() + 
 Create and manage recurring subscriptions:
 
 ```java
-import com.dodopayments.api.models.subscriptions.*;
+import com.dodopayments.api.models.payments.AttachExistingCustomer;
+import com.dodopayments.api.models.payments.BillingAddress;
+import com.dodopayments.api.models.payments.CountryCode;
+import com.dodopayments.api.models.subscriptions.SubscriptionChargeParams;
+import com.dodopayments.api.models.subscriptions.SubscriptionChargeResponse;
+import com.dodopayments.api.models.subscriptions.SubscriptionCreateParams;
+import com.dodopayments.api.models.subscriptions.SubscriptionCreateResponse;
 
 // Create a subscription
-SubscriptionNewParams subscriptionParams = SubscriptionNewParams.builder()
-    .customerId("cus_123")
-    .productId("prod_456")
-    .priceId("price_789")
+SubscriptionCreateParams subscriptionParams = SubscriptionCreateParams.builder()
+    .billing(BillingAddress.builder()
+        .city("San Francisco")
+        .country(CountryCode.US)
+        .state("CA")
+        .street("1 Market St")
+        .zipcode("94105")
+        .build())
+    .customer(AttachExistingCustomer.builder()
+        .customerId("cus_123")
+        .build())
+    .productId("pdt_456")
+    .quantity(1)
+    .paymentLink(true)
+    .returnUrl("https://yourdomain.com/return")
     .build();
 
-Subscription subscription = client.subscriptions().create(subscriptionParams);
+SubscriptionCreateResponse subscription = client.subscriptions().create(subscriptionParams);
+System.out.println("Subscription ID: " + subscription.subscriptionId());
 
-// Charge subscription
+// Charge an on-demand subscription
+// product_price is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
 SubscriptionChargeParams chargeParams = SubscriptionChargeParams.builder()
-    .amount(1000)
+    .subscriptionId(subscription.subscriptionId())
+    .productPrice(2500)
     .build();
 
-SubscriptionChargeResponse chargeResponse = client.subscriptions()
-    .charge(subscription.id(), chargeParams);
+SubscriptionChargeResponse chargeResponse = client.subscriptions().charge(chargeParams);
+System.out.println("Payment ID: " + chargeResponse.paymentId());
 ```
+
+<Info>
+`productPrice` is expressed in the lowest currency denomination (e.g., cents for USD, paise for INR). To charge $25.00, pass `2500`.
+</Info>
+
+<Tip>
+Charging via `subscriptions().charge(...)` is intended for [on-demand subscriptions](/developer-resources/ondemand-subscriptions). Standard scheduled subscriptions are billed automatically based on the product's pricing schedule.
+</Tip>
 
 ## Usage-Based Billing
 


### PR DESCRIPTION
## Summary
Fixes the outdated Java SDK code in the "Handle Subscriptions" section of `/developer-resources/sdks/java`, as reported by @willedwards in #260. The previous sample referenced classes and fields that don't exist on the current SDK (v1.97.1), so it would not compile.

## Closes
- #260

## What was wrong
The old sample used:
- `SubscriptionNewParams` — class doesn't exist (it's `SubscriptionCreateParams`)
- `.customerId("cus_123")` — should be `.customer(AttachExistingCustomer.builder()...)`
- `.priceId("price_789")` — Dodo's subscription API has no `priceId`; pricing is derived from the product
- Missing required fields: `.billing(...)` and `.quantity(...)` (per [SubscriptionCreateParams.kt L405-L411](https://github.com/dodopayments/dodopayments-java/blob/main/dodo-payments-java-core/src/main/kotlin/com/dodopayments/api/models/subscriptions/SubscriptionCreateParams.kt))
- `SubscriptionChargeParams.builder().amount(1000)` — field is `productPrice`, not `amount` (per [SubscriptionChargeParams.kt](https://github.com/dodopayments/dodopayments-java/blob/main/dodo-payments-java-core/src/main/kotlin/com/dodopayments/api/models/subscriptions/SubscriptionChargeParams.kt))
- `client.subscriptions().charge(subscription.id(), chargeParams)` — current SDK signature is `charge(SubscriptionChargeParams)` with `subscriptionId` set on the params builder

## What changed
- Replaced the entire sample with code that matches the actual `dodo-payments-java` v1.97.1 SDK surface
- Switched to explicit imports (instead of wildcard) so readers can map types to docs
- Added an Info callout clarifying `productPrice` is in the lowest currency denomination
- Added a Tip noting that `subscriptions().charge(...)` targets on-demand subscriptions, linking to the on-demand guide
- Bumped Maven/Gradle dependency version `1.86.3` → `1.97.1` (current Maven Central release)

## Verification
- Field names, required fields, and method signatures cross-checked against the SDK source on `main` and the v1.97.1 README/Javadoc references on Maven Central
- Translated locale files intentionally left untouched (handled separately)