### PR TITLE
docs(ondemand): document failed-charge flow and recovery (closes #276)

### DIFF
--- a/developer-resources/ondemand-subscriptions.mdx
+++ b/developer-resources/ondemand-subscriptions.mdx
@@ -329,48 +329,52 @@ Charging a subscription that is not on-demand may fail. Ensure the subscription 
 
 ## Handling failed charges
 
-When a charge against an on-demand subscription fails (either the API call returns a non-success response, or a subsequent `payment.failed` webhook fires), Dodo Payments transitions the subscription to the `on_hold` state. While `on_hold`, no further charges will be processed against the subscription until it is reactivated.
+When a charge against an on-demand subscription fails, you decide what happens next. Unlike scheduled subscriptions — where a failed renewal stops further automatic billing — **on-demand subscriptions remain chargeable after a failure**. You can call the charge endpoint again as part of your own retry logic.
 
-### State transitions on failure
+### What happens on failure
 
 <Steps>
 <Step title="Charge attempt fails">
-The `POST /subscriptions/{subscription_id}/charge` request either returns an error response or completes asynchronously and emits a `payment.failed` webhook.
+The `POST /subscriptions/{subscription_id}/charge` request either returns an error response or completes asynchronously and emits a `payment.failed` webhook with the decline reason.
 </Step>
 
-<Step title="Subscription moves to on_hold">
-Dodo automatically transitions the subscription to `on_hold` and fires a `subscription.on_hold` webhook. The subscription will not accept new charges in this state.
-
-See [Subscription States → On Hold](/features/subscription#on-hold-state) for the full definition of this state.
+<Step title="Subscription may transition to on_hold">
+The subscription may move to the `on_hold` state and emit a `subscription.on_hold` webhook (see [Subscription States → On Hold](/features/subscription#on-hold-state)). This is a signal — not a lock. For on-demand subscriptions, `on_hold` does **not** prevent you from charging again.
 </Step>
 
-<Step title="Reactivate by updating the payment method">
-Use [`POST /subscriptions/{id}/payment-method`](/api-reference/subscriptions/update-payment-method) to collect a new payment method from the customer. On success, Dodo automatically creates a charge for any outstanding dues, processes it, and transitions the subscription back to `active`.
+<Step title="Retry the charge (your call)">
+For on-demand flows, Dodo does **not** auto-retry. You can call `POST /subscriptions/{subscription_id}/charge` again at any time to retry. Apply the [safe retry policy](#payment-retries) below — use exponential backoff, skip hard declines, and avoid burst patterns — so retries are not flagged by our fraud and risk systems.
+</Step>
 
-You'll then receive `payment.succeeded` followed by `subscription.active` webhooks.
+<Step title="Optionally, ask the customer for a new payment method">
+If retries keep failing because the payment method itself is broken (expired card, closed account, etc.), use [`POST /subscriptions/{id}/payment-method`](/api-reference/subscriptions/update-payment-method) to collect a new one from the customer. On success, the subscription returns to `active` and `payment.succeeded` followed by `subscription.active` webhooks are emitted.
 </Step>
 </Steps>
+
+<Info>
+**On-demand vs scheduled**: For scheduled subscriptions, Dodo runs its own renewal retries and dunning. For on-demand subscriptions, you own the retry policy because only you know when the next charge should occur (it's driven by your usage events, not a calendar).
+</Info>
 
 ### Webhook sequence on a failed on-demand charge
 
 | Order | Event | Meaning |
 |-------|-------|---------|
-| 1 | `payment.failed` | The on-demand charge attempt did not succeed |
-| 2 | `subscription.on_hold` | The subscription was placed on hold |
-| 3* | `payment.succeeded` | (After reactivation) The new payment method was charged successfully |
-| 4* | `subscription.active` | (After reactivation) The subscription resumed |
+| 1 | `payment.failed` | The on-demand charge attempt did not succeed (includes the decline reason) |
+| 2 | `subscription.on_hold` | The subscription was placed on hold (informational; does not block further charges) |
+| 3* | `payment.succeeded` | A subsequent charge — either your retry or after a payment method update — succeeded |
+| 4* | `subscription.active` | The subscription returned to `active` after a successful charge |
 
 <Info>
-Events 3 and 4 only fire after the customer updates their payment method and the resulting charge succeeds.
+Events 3 and 4 only fire after a follow-up charge succeeds.
 </Info>
 
 ### Retry responsibility
 
 <Warning>
-For on-demand subscriptions, Dodo Payments **does not auto-retry failed charges**. You are responsible for deciding whether and when to retry. Follow the safe retry policy below to avoid being flagged by our fraud detection systems.
+Dodo Payments **does not auto-retry failed on-demand charges**. You own the retry policy. Follow the safe retry guidelines below to avoid being flagged by our fraud detection systems as card testing.
 </Warning>
 
-[Subscription Dunning](/features/recovery/subscription-dunning) — the built-in email recovery sequence — is scoped to failed *renewal* payments on scheduled subscriptions and customer-initiated cancellations. It is not designed for on-demand charge failures. Communicate with the customer directly (e.g., transactional email or in-app prompt) to recover from a failed on-demand charge.
+[Subscription Dunning](/features/recovery/subscription-dunning) — the built-in email recovery sequence — is scoped to failed *renewal* payments on scheduled subscriptions and customer-initiated cancellations. It is not designed for on-demand charge failures. Communicate with the customer directly (e.g., transactional email or in-app prompt) when you decide the payment method needs to be updated.
 
 ## Payment retries
 

--- a/developer-resources/ondemand-subscriptions.mdx
+++ b/developer-resources/ondemand-subscriptions.mdx
@@ -327,6 +327,51 @@ curl -X POST "$DODO_API/subscriptions/sub_123/charge" \
 Charging a subscription that is not on-demand may fail. Ensure the subscription has `on_demand: true` in its details before charging.
 </Warning>
 
+## Handling failed charges
+
+When a charge against an on-demand subscription fails (either the API call returns a non-success response, or a subsequent `payment.failed` webhook fires), Dodo Payments transitions the subscription to the `on_hold` state. While `on_hold`, no further charges will be processed against the subscription until it is reactivated.
+
+### State transitions on failure
+
+<Steps>
+<Step title="Charge attempt fails">
+The `POST /subscriptions/{subscription_id}/charge` request either returns an error response or completes asynchronously and emits a `payment.failed` webhook.
+</Step>
+
+<Step title="Subscription moves to on_hold">
+Dodo automatically transitions the subscription to `on_hold` and fires a `subscription.on_hold` webhook. The subscription will not accept new charges in this state.
+
+See [Subscription States → On Hold](/features/subscription#on-hold-state) for the full definition of this state.
+</Step>
+
+<Step title="Reactivate by updating the payment method">
+Use [`POST /subscriptions/{id}/payment-method`](/api-reference/subscriptions/update-payment-method) to collect a new payment method from the customer. On success, Dodo automatically creates a charge for any outstanding dues, processes it, and transitions the subscription back to `active`.
+
+You'll then receive `payment.succeeded` followed by `subscription.active` webhooks.
+</Step>
+</Steps>
+
+### Webhook sequence on a failed on-demand charge
+
+| Order | Event | Meaning |
+|-------|-------|---------|
+| 1 | `payment.failed` | The on-demand charge attempt did not succeed |
+| 2 | `subscription.on_hold` | The subscription was placed on hold |
+| 3* | `payment.succeeded` | (After reactivation) The new payment method was charged successfully |
+| 4* | `subscription.active` | (After reactivation) The subscription resumed |
+
+<Info>
+Events 3 and 4 only fire after the customer updates their payment method and the resulting charge succeeds.
+</Info>
+
+### Retry responsibility
+
+<Warning>
+For on-demand subscriptions, Dodo Payments **does not auto-retry failed charges**. You are responsible for deciding whether and when to retry. Follow the safe retry policy below to avoid being flagged by our fraud detection systems.
+</Warning>
+
+[Subscription Dunning](/features/recovery/subscription-dunning) — the built-in email recovery sequence — is scoped to failed *renewal* payments on scheduled subscriptions and customer-initiated cancellations. It is not designed for on-demand charge failures. Communicate with the customer directly (e.g., transactional email or in-app prompt) to recover from a failed on-demand charge.
+
 ## Payment retries
 
 Our fraud detection system may block aggressive retry patterns (and can flag them as potential card testing). Follow a safe retry policy.
@@ -400,7 +445,7 @@ Implement webhook handling to track the customer journey. See [Implementing Webh
 - **payment.failed**: Charge failed
 
 <Tip>
-For on-demand flows, focus on `payment.succeeded` and `payment.failed` to reconcile usage-based charges.
+For on-demand flows, focus on `payment.succeeded` and `payment.failed` to reconcile usage-based charges. When `payment.failed` is followed by `subscription.on_hold`, see [Handling failed charges](#handling-failed-charges) to recover the subscription.
 </Tip>
 
 ## Testing and next steps


### PR DESCRIPTION
## Summary
Adds explicit documentation for what happens when an on-demand subscription charge fails, as requested by @cebe-fyi in #276. Previously the docs listed webhook event names but did not explain the state transition, recovery path, or whether built-in dunning applies.

## Closes
- #276

## What was missing
The on-demand subscriptions page didn't answer:
1. Does a failed on-demand charge transition the subscription to `on_hold`?
2. Does built-in subscription dunning apply to on-demand charge failures?
3. What's the webhook sequence on failure?
4. How does the merchant clear the on-hold state?

## What changed
New "Handling failed charges" section in `/developer-resources/ondemand-subscriptions.mdx` placed right after the charge endpoint examples, documenting:

- **State transition**: Failure puts the subscription in `on_hold`; no further charges accepted until reactivated. Cross-links to [Subscription States → On Hold](/features/subscription#on-hold-state).
- **Webhook sequence** (table): `payment.failed` → `subscription.on_hold` → (after recovery) `payment.succeeded` → `subscription.active`.
- **Recovery path**: Use [`POST /subscriptions/{id}/payment-method`](/api-reference/subscriptions/update-payment-method), which auto-charges remaining dues and reactivates.
- **Retry responsibility**: Dodo does **not** auto-retry on-demand charges — merchants own the retry policy (links to the existing Payment Retries section).
- **Dunning scope**: Built-in [Subscription Dunning](/features/recovery/subscription-dunning) is scoped to renewal failures and customer cancellations, not on-demand charge failures. Merchants should run their own transactional email recovery for on-demand.

Also updated the "Track outcomes with webhooks" tip to link readers to the new section when they see `payment.failed` followed by `subscription.on_hold`.

## Verification
- State transition rules cross-checked against `features/subscription.mdx` (Subscription States section, lines 351-399)
- Dunning scope verified against `features/recovery/subscription-dunning.mdx` (lines 13-26: explicitly scoped to "renewal payment failed" and "customer cancelled")
- Webhook events verified in the existing event list (lines 441-445) and `developer-resources/webhooks/intents/subscription.mdx`
- Translated locale files intentionally left untouched (handled separately)