### PR TITLE
docs(sdks): fix outdated Handle Subscriptions samples across all SDKs

### DIFF
--- a/developer-resources/sdks/csharp.mdx
+++ b/developer-resources/sdks/csharp.mdx
@@ -178,17 +178,36 @@ Console.WriteLine($"Customer: {retrieved.Name} ({retrieved.Email})");
 ### Handle Subscriptions
 
 ```csharp
+using DodoPayments.Client.Models.Payments;
+using DodoPayments.Client.Models.Subscriptions;
+
 // Create a subscription
 var subscription = await client.Subscriptions.Create(new SubscriptionCreateParams
 {
-    CustomerID = "cus_123",
-    ProductID = "prod_456",
-    PriceID = "price_789"
+    Billing = new BillingAddress
+    {
+        Country = "US",
+        City = "San Francisco",
+        State = "CA",
+        Street = "1 Market St",
+        Zipcode = "94105",
+    },
+    Customer = new AttachExistingCustomer { CustomerID = "cus_123" },
+    ProductID = "pdt_456",
+    Quantity = 1,
 });
 
-// Cancel subscription
-await client.Subscriptions.Cancel(subscription.Id);
+// Charge an on-demand subscription
+// ProductPrice is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+var charge = await client.Subscriptions.Charge(
+    subscription.SubscriptionId,
+    new SubscriptionChargeParams { ProductPrice = 2500 }
+);
 ```
+
+<Info>
+`Billing` requires at minimum the two-letter ISO `Country` code. Use `AttachExistingCustomer` to attach an existing customer, or `NewCustomer` to create one. `ProductPrice` is in the lowest currency denomination.
+</Info>
 
 ## Error Handling
 

--- a/developer-resources/sdks/go.mdx
+++ b/developer-resources/sdks/go.mdx
@@ -18,7 +18,7 @@ go get github.com/dodopayments/dodopayments-go
 Or to pin to a specific version:
 
 ```bash
-go get -u 'github.com/dodopayments/dodopayments-go@v1.86.1'
+go get -u 'github.com/dodopayments/dodopayments-go@v1.97.3'
 ```
 
 <Info>
@@ -198,29 +198,57 @@ fmt.Printf("Customer: %s (%s)\n", customer.Name, customer.Email)
 Create and manage recurring subscriptions:
 
 ```go
+import "time"
+
 // Create a subscription
 subscription, err := client.Subscriptions.New(ctx, dodopayments.SubscriptionNewParams{
-	CustomerID: dodopayments.F("cus_123"),
-	ProductID:  dodopayments.F("prod_456"),
-	PriceID:    dodopayments.F("price_789"),
+	Billing: dodopayments.F(dodopayments.BillingAddressParam{
+		Country: dodopayments.F(dodopayments.CountryCodeUs),
+		City:    dodopayments.F("San Francisco"),
+		State:   dodopayments.F("CA"),
+		Street:  dodopayments.F("1 Market St"),
+		Zipcode: dodopayments.F("94105"),
+	}),
+	Customer: dodopayments.F[dodopayments.CustomerRequestUnionParam](
+		dodopayments.AttachExistingCustomerParam{
+			CustomerID: dodopayments.F("cus_123"),
+		},
+	),
+	ProductID: dodopayments.F("pdt_456"),
+	Quantity:  dodopayments.F(int64(1)),
 })
 if err != nil {
 	log.Fatal(err)
 }
 
-// Get usage history
+// Charge an on-demand subscription
+// ProductPrice is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+chargeResponse, err := client.Subscriptions.Charge(ctx, subscription.SubscriptionID,
+	dodopayments.SubscriptionChargeParams{
+		ProductPrice: dodopayments.F(int64(2500)),
+	},
+)
+if err != nil {
+	log.Fatal(err)
+}
+
+// Get usage history (for metered subscriptions)
 usageHistory, err := client.Subscriptions.GetUsageHistory(
 	ctx,
-	subscription.ID,
+	subscription.SubscriptionID,
 	dodopayments.SubscriptionGetUsageHistoryParams{
-		StartDate: dodopayments.F("2024-01-01T00:00:00Z"),
-		EndDate:   dodopayments.F("2024-03-31T23:59:59Z"),
+		StartDate: dodopayments.F(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+		EndDate:   dodopayments.F(time.Date(2024, 3, 31, 23, 59, 59, 0, time.UTC)),
 	},
 )
 if err != nil {
 	log.Fatal(err)
 }
 ```
+
+<Info>
+`Billing` requires at minimum the two-letter ISO `Country` code. `Customer` is a `CustomerRequestUnionParam` — pass `AttachExistingCustomerParam{CustomerID: ...}` for an existing customer or `NewCustomerParam{Email: ..., Name: ...}` for a new one. `ProductPrice` is in the lowest currency denomination.
+</Info>
 
 ## Usage-Based Billing
 

--- a/developer-resources/sdks/kotlin.mdx
+++ b/developer-resources/sdks/kotlin.mdx
@@ -14,7 +14,7 @@ The Kotlin SDK provides convenient access to the Dodo Payments REST API from app
 Add the dependency to your `build.gradle.kts`:
 
 ```kotlin build.gradle.kts
-implementation("com.dodopayments.api:dodo-payments-kotlin:1.86.3")
+implementation("com.dodopayments.api:dodo-payments-kotlin:1.97.1")
 ```
 
 ### Maven
@@ -25,7 +25,7 @@ Add the dependency to your `pom.xml`:
 <dependency>
   <groupId>com.dodopayments.api</groupId>
   <artifactId>dodo-payments-kotlin</artifactId>
-  <version>1.86.3</version>
+  <version>1.97.1</version>
 </dependency>
 ```
 
@@ -217,6 +217,51 @@ try {
     println("License activation failed: ${e.message}")
 }
 ```
+
+### Handle Subscriptions
+
+Create and manage recurring subscriptions:
+
+```kotlin
+import com.dodopayments.api.models.payments.AttachExistingCustomer
+import com.dodopayments.api.models.payments.BillingAddress
+import com.dodopayments.api.models.payments.CountryCode
+import com.dodopayments.api.models.subscriptions.SubscriptionChargeParams
+import com.dodopayments.api.models.subscriptions.SubscriptionCreateParams
+
+// Create a subscription
+val subscriptionParams = SubscriptionCreateParams.builder()
+    .billing(BillingAddress.builder()
+        .city("San Francisco")
+        .country(CountryCode.US)
+        .state("CA")
+        .street("1 Market St")
+        .zipcode("94105")
+        .build())
+    .customer(AttachExistingCustomer.builder()
+        .customerId("cus_123")
+        .build())
+    .productId("pdt_456")
+    .quantity(1)
+    .build()
+
+val subscription = client.subscriptions().create(subscriptionParams)
+println("Subscription ID: ${subscription.subscriptionId()}")
+
+// Charge an on-demand subscription
+// productPrice is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+val chargeParams = SubscriptionChargeParams.builder()
+    .subscriptionId(subscription.subscriptionId())
+    .productPrice(2500)
+    .build()
+
+val chargeResponse = client.subscriptions().charge(chargeParams)
+println("Payment ID: ${chargeResponse.paymentId()}")
+```
+
+<Info>
+`billing` requires at minimum a two-letter ISO `country` code. Use `AttachExistingCustomer` to attach an existing customer, or `NewCustomer` to create one. `productPrice` is expressed in the lowest currency denomination.
+</Info>
 
 ## Usage-Based Billing
 

--- a/developer-resources/sdks/php.mdx
+++ b/developer-resources/sdks/php.mdx
@@ -13,7 +13,7 @@ The PHP SDK provides a robust and flexible way to integrate Dodo Payments into y
 Install the SDK using Composer:
 
 ```bash
-composer require "dodopayments/client 5.8.1"
+composer require "dodopayments/client 6.7.1"
 ```
 
 <Info>
@@ -162,16 +162,34 @@ echo "Customer: {$customer->name} ({$customer->email})";
 Create and manage recurring subscriptions:
 
 ```php
+use Dodopayments\Customers\AttachExistingCustomer;
+use Dodopayments\Payments\BillingAddress;
+
 // Create a subscription
 $subscription = $client->subscriptions->create(
-  customerID: "cus_123",
-  productID: "prod_456",
-  priceID: "price_789"
+  billing: BillingAddress::with(
+    country: 'US',
+    city: 'San Francisco',
+    state: 'CA',
+    street: '1 Market St',
+    zipcode: '94105',
+  ),
+  customer: AttachExistingCustomer::with(customerID: 'cus_123'),
+  productID: 'pdt_456',
+  quantity: 1,
 );
 
-// Cancel subscription
-$client->subscriptions->cancel($subscription->id);
+// Charge an on-demand subscription
+// productPrice is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+$charge = $client->subscriptions->charge(
+  $subscription->subscription_id,
+  productPrice: 2500,
+);
 ```
+
+<Info>
+`billing` requires at minimum the two-letter ISO `country` code. Pass `AttachExistingCustomer::with(customerID: '...')` to attach an existing customer, or `NewCustomer::with(email: '...', name: '...')` to create one. `productPrice` is in the lowest currency denomination.
+</Info>
 
 ## Pagination
 

--- a/developer-resources/sdks/python.mdx
+++ b/developer-resources/sdks/python.mdx
@@ -209,17 +209,35 @@ Create and manage recurring subscriptions:
 ```python
 # Create a subscription
 subscription = client.subscriptions.create(
-    customer_id="cus_123",
-    product_id="prod_456",
-    price_id="price_789"
+    billing={
+        "country": "US",
+        "city": "San Francisco",
+        "state": "CA",
+        "street": "1 Market St",
+        "zipcode": "94105",
+    },
+    customer={"customer_id": "cus_123"},  # or {"email": "...", "name": "..."} for a new customer
+    product_id="pdt_456",
+    quantity=1,
 )
 
-# Retrieve usage history
+# Charge an on-demand subscription
+# product_price is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+charge_response = client.subscriptions.charge(
+    subscription_id=subscription.subscription_id,
+    product_price=2500,
+)
+
+# Retrieve usage history (for metered subscriptions)
 usage_history = client.subscriptions.retrieve_usage_history(
-    subscription.id,
-    start_date="2024-01-01T00:00:00Z"
+    subscription_id=subscription.subscription_id,
+    start_date="2024-01-01T00:00:00Z",
 )
 ```
+
+<Info>
+`billing` requires at minimum the two-letter ISO country code. `customer` accepts either `{"customer_id": ...}` to attach an existing customer or `{"email": ..., "name": ...}` to create a new one. `product_price` is in the lowest currency denomination.
+</Info>
 
 ## Usage-Based Billing
 

--- a/developer-resources/sdks/ruby.mdx
+++ b/developer-resources/sdks/ruby.mdx
@@ -12,7 +12,7 @@ The Ruby SDK provides a simple and intuitive way to integrate Dodo Payments into
 Add the gem to your Gemfile:
 
 ```ruby Gemfile
-gem "dodopayments", "~> 2.0.0"
+gem "dodopayments", "~> 2.9"
 ```
 
 <Tip>
@@ -156,20 +156,35 @@ Create and manage recurring subscriptions:
 ```ruby
 # Create a subscription
 subscription = dodo_payments.subscriptions.create(
-  customer_id: "cus_123",
-  product_id: "prod_456",
-  price_id: "price_789"
+  billing: {
+    country: "US",
+    city: "San Francisco",
+    state: "CA",
+    street: "1 Market St",
+    zipcode: "94105"
+  },
+  customer: { customer_id: "cus_123" }, # or { email: "...", name: "..." } for a new customer
+  product_id: "pdt_456",
+  quantity: 1
 )
 
-# Update subscription
+# Charge an on-demand subscription
+# product_price is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+charge = dodo_payments.subscriptions.charge(
+  subscription.subscription_id,
+  product_price: 2500
+)
+
+# Update subscription metadata
 updated = dodo_payments.subscriptions.update(
-  subscription.id,
+  subscription.subscription_id,
   metadata: { plan_type: "premium" }
 )
-
-# Cancel subscription
-dodo_payments.subscriptions.cancel(subscription.id)
 ```
+
+<Info>
+`billing` requires at minimum the two-letter ISO `country` code. `customer` accepts either `{ customer_id: "..." }` to attach an existing customer or `{ email: "...", name: "..." }` to create a new one. `product_price` is in the lowest currency denomination.
+</Info>
 
 ## Pagination
 

--- a/developer-resources/sdks/typescript.mdx
+++ b/developer-resources/sdks/typescript.mdx
@@ -161,17 +161,36 @@ Create and manage recurring subscriptions:
 ```typescript
 // Create a subscription
 const subscription = await client.subscriptions.create({
-  customer_id: 'cus_123',
-  product_id: 'prod_456',
-  price_id: 'price_789'
+  billing: {
+    country: 'US',
+    city: 'San Francisco',
+    state: 'CA',
+    street: '1 Market St',
+    zipcode: '94105',
+  },
+  customer: {
+    customer_id: 'cus_123', // or pass { email, name } to create a new customer
+  },
+  product_id: 'pdt_456',
+  quantity: 1,
 });
 
-// Retrieve subscription usage history
-const usageHistory = await client.subscriptions.retrieveUsageHistory('sub_123', {
+// Charge an on-demand subscription
+// product_price is in the lowest currency denomination (e.g., 2500 = $25.00 USD)
+const chargeResponse = await client.subscriptions.charge(subscription.subscription_id, {
+  product_price: 2500,
+});
+
+// Retrieve subscription usage history (for metered subscriptions)
+const usageHistory = await client.subscriptions.retrieveUsageHistory(subscription.subscription_id, {
   start_date: '2024-01-01T00:00:00Z',
-  end_date: '2024-03-31T23:59:59Z'
+  end_date: '2024-03-31T23:59:59Z',
 });
 ```
+
+<Info>
+`billing` requires at minimum the two-letter ISO country code. `customer` is a union of `{ customer_id }` (to attach an existing customer) or `{ email, name? }` (to create a new one). `product_price` is expressed in the lowest currency denomination.
+</Info>
 
 ## Usage-Based Billing
 


### PR DESCRIPTION
## Summary
Following PR #278 (which fixed the Java SDK), this brings the **Handle Subscriptions** code samples in line with the current SDK surface for **TypeScript, Python, Go, Ruby, Kotlin, PHP, and C#**.

The old samples all used the same wrong pattern across every language:
\`\`\`
customer_id: 'cus_123',
product_id: 'prod_456',
price_id: 'price_789'   ← this field has never existed
\`\`\`

The real API (verified against each SDK's source) requires:
- \`billing\` — \`BillingAddress\` with at minimum the two-letter ISO country code
- \`customer\` — union of \`AttachExistingCustomer\` (\`customer_id\`) or \`NewCustomer\` (\`email\`, \`name\`)
- \`product_id\`
- \`quantity\` (≥ 1)

There is no \`price_id\`. Charging an on-demand subscription uses \`product_price\` (in the lowest currency denomination, e.g. \`2500\` = \$25.00 USD).

## Per-SDK changes

| SDK | Subscriptions fix | Version pin bumped |
|---|---|---|
| TypeScript | ✅ | — (uses semver via npm) |
| Python | ✅ | — (uses semver via pip) |
| Go | ✅ + on-demand \`Charge\` + typed \`time.Time\` for usage history | \`v1.86.1\` → \`v1.97.3\` |
| Ruby | ✅ + on-demand \`charge\` | \`~> 2.0.0\` → \`~> 2.9\` |
| Kotlin | ✅ — added a new \"Handle Subscriptions\" section (the page didn't have one) | \`1.86.3\` → \`1.97.1\` |
| PHP | ✅ + on-demand \`charge\` | \`5.8.1\` → \`6.7.1\` |
| C# | ✅ + on-demand \`Charge\` | — (no version pin shown in doc) |

## Verification
For each SDK, the code was cross-checked against the actual \`SubscriptionCreateParams\`/\`SubscriptionChargeParams\` source files in the official repos:
- TypeScript: [\`src/resources/subscriptions.ts\`](https://github.com/dodopayments/dodopayments-node/blob/main/src/resources/subscriptions.ts) (v2.31.1)
- Python: [\`src/dodopayments/types/subscription_create_params.py\`](https://github.com/dodopayments/dodopayments-python/blob/main/src/dodopayments/types/subscription_create_params.py) (v1.98.1)
- Go: [\`subscription.go\`](https://github.com/dodopayments/dodopayments-go/blob/main/subscription.go) (v1.97.3)
- Ruby: [\`lib/dodopayments/resources/subscriptions.rb\`](https://github.com/dodopayments/dodopayments-ruby/blob/main/lib/dodopayments/resources/subscriptions.rb) (v2.9.1)
- Kotlin: [\`SubscriptionCreateParams.kt\`](https://github.com/dodopayments/dodopayments-kotlin/blob/main/dodo-payments-kotlin-core/src/main/kotlin/com/dodopayments/api/models/subscriptions/SubscriptionCreateParams.kt) (v1.97.1)
- PHP: [\`src/Subscriptions/SubscriptionCreateParams.php\`](https://github.com/dodopayments/dodopayments-php/blob/main/src/Subscriptions/SubscriptionCreateParams.php) (v6.7.1)
- C#: [\`SubscriptionCreateParams.cs\`](https://github.com/dodopayments/dodopayments-csharp/blob/main/src/DodoPayments.Client/Models/Subscriptions/SubscriptionCreateParams.cs) (v6.18.0)

## Out of scope (follow-ups)
While auditing, I noticed unrelated stale samples that I did NOT fix here to keep this PR focused:
- Go doc's \"Context and Timeouts\" and \"Concurrency\" sections call \`client.Payments.Create(ctx, dodopayments.PaymentCreateParams{Amount: ..., Currency: ..., CustomerID: ...})\`. The real signature is \`client.Payments.New(ctx, PaymentNewParams{Billing, Customer, ProductCart, ...})\`.
- Ruby/PHP/C# docs reference \`subscriptions.cancel(id)\` — needs verification against current SDKs (cancellation may now be done via \`update(id, status: \"cancelled\")\`).
- Translated locale files (es/, fr/, de/, it/, ja/, ko/, cn/, ar/, hi/, id/, pt-BR/, sv/, vi/) intentionally left untouched.

These deserve a separate PR.