### PR TITLE
docs(cli): rename to Dodo CLI, add NEW tag, install.sh primary, mention on homepage

### DIFF
--- a/developer-resources/sdks/cli.mdx
+++ b/developer-resources/sdks/cli.mdx
@@ -17,8 +17,30 @@ Manage your Dodo Payments resources, run AI-powered queries against your account
 
 ## Installation
 
+Install the CLI in one line on macOS or Linux:
+
+```bash
+curl -fsSL https://dodopayments.com/install.sh | sh
+```
+
+The script detects your OS and architecture, downloads the matching prebuilt binary from [GitHub Releases](https://github.com/dodopayments/dodopayments-cli/releases), verifies its SHA-256 checksum, and installs `dodo` to a directory on your `PATH` (no Node, Bun, or `sudo` required when `~/.local/bin` is writable).
+
+<Tip>
+You can pin a specific version or override the install directory with environment variables:
+
+```bash
+DODO_VERSION=v3.1.0 DODO_INSTALL_DIR=$HOME/bin curl -fsSL https://dodopayments.com/install.sh | sh
+```
+
+Set `DODO_NO_VERIFY=1` to skip checksum verification (not recommended).
+</Tip>
+
+### Install with npm or Bun
+
+If you already have Node or Bun, the package-manager installs always pull the latest version:
+
 <CodeGroup>
-```bash npm (Recommended)
+```bash npm
 npm install -g dodopayments-cli
 ```
 
@@ -27,11 +49,9 @@ bun install -g dodopayments-cli
 ```
 </CodeGroup>
 
-<Tip>
-If you already have Node or Bun installed, the package-manager installs are the simplest path and always pull the latest version.
-</Tip>
-
 ### Manual installation (no Node / Bun required)
+
+If you'd rather not pipe a remote script to `sh`, download the binary yourself.
 
 <Steps>
 <Step title="Download the binary">
@@ -346,9 +366,13 @@ The CLI checks for a newer version on startup and surfaces a notification in the
 /update
 ```
 
-Or, if you installed via a package manager, the usual reinstall command will also work:
+Or, re-run the installer to upgrade in place:
 
 <CodeGroup>
+```bash install.sh
+curl -fsSL https://dodopayments.com/install.sh | sh
+```
+
 ```bash npm
 npm install -g dodopayments-cli
 ```

--- a/developer-resources/sdks/cli.mdx
+++ b/developer-resources/sdks/cli.mdx
@@ -1,8 +1,9 @@
 ---
-title: 'CLI'
-description: 'Command-line interface for interacting with the Dodo Payments API from your terminal'
+title: "Dodo CLI"
+description: "The official command-line interface for Dodo Payments — manage resources, run AI-powered queries, create checkout sessions, and test webhooks from your terminal."
 icon: "terminal"
-keywords: ["Dodo Payments", "CLI", "command line", "terminal", "TUI", "AI assistant", "MCP"]
+tag: "NEW"
+keywords: ["Dodo Payments", "Dodo CLI", "CLI", "command line", "terminal", "TUI", "AI assistant", "MCP"]
 ---
 
 Manage your Dodo Payments resources, run AI-powered queries against your account, create checkout sessions, and test webhooks — all from the terminal. The CLI ships with an interactive TUI, a built-in AI assistant powered by MCP, and offline webhook testing.
@@ -22,18 +23,6 @@ Install the CLI in one line on macOS or Linux:
 ```bash
 curl -fsSL https://dodopayments.com/install.sh | sh
 ```
-
-The script detects your OS and architecture, downloads the matching prebuilt binary from [GitHub Releases](https://github.com/dodopayments/dodopayments-cli/releases), verifies its SHA-256 checksum, and installs `dodo` to a directory on your `PATH` (no Node, Bun, or `sudo` required when `~/.local/bin` is writable).
-
-<Tip>
-You can pin a specific version or override the install directory with environment variables:
-
-```bash
-DODO_VERSION=v3.1.0 DODO_INSTALL_DIR=$HOME/bin curl -fsSL https://dodopayments.com/install.sh | sh
-```
-
-Set `DODO_NO_VERIFY=1` to skip checksum verification (not recommended).
-</Tip>
 
 ### Install with npm or Bun
 

--- a/docs.json
+++ b/docs.json
@@ -202,7 +202,6 @@
                       "developer-resources/sdks/ruby",
                       "developer-resources/sdks/java",
                       "developer-resources/sdks/kotlin",
-                      "developer-resources/sdks/cli",
                       "developer-resources/sdks/php",
                       "developer-resources/sdks/csharp",
                       "developer-resources/react-native-integration"
@@ -281,6 +280,7 @@
                       "developer-resources/go-boilerplate"
                     ]
                   },
+                  "developer-resources/sdks/cli",
                   "developer-resources/overlay-checkout",
                   "developer-resources/inline-checkout",
                   "developer-resources/sentra",
@@ -1006,7 +1006,6 @@
                       "es/developer-resources/sdks/ruby",
                       "es/developer-resources/sdks/java",
                       "es/developer-resources/sdks/kotlin",
-                      "es/developer-resources/sdks/cli",
                       "es/developer-resources/sdks/php",
                       "es/developer-resources/sdks/csharp",
                       "es/developer-resources/react-native-integration"
@@ -1085,6 +1084,7 @@
                       "es/developer-resources/go-boilerplate"
                     ]
                   },
+                  "es/developer-resources/sdks/cli",
                   "es/developer-resources/overlay-checkout",
                   "es/developer-resources/inline-checkout",
                   "es/developer-resources/sentra",
@@ -1807,7 +1807,6 @@
                       "ar/developer-resources/sdks/ruby",
                       "ar/developer-resources/sdks/java",
                       "ar/developer-resources/sdks/kotlin",
-                      "ar/developer-resources/sdks/cli",
                       "ar/developer-resources/sdks/php",
                       "ar/developer-resources/sdks/csharp",
                       "ar/developer-resources/react-native-integration"
@@ -1886,6 +1885,7 @@
                       "ar/developer-resources/go-boilerplate"
                     ]
                   },
+                  "ar/developer-resources/sdks/cli",
                   "ar/developer-resources/overlay-checkout",
                   "ar/developer-resources/inline-checkout",
                   "ar/developer-resources/sentra",
@@ -2607,7 +2607,6 @@
                       "fr/developer-resources/sdks/ruby",
                       "fr/developer-resources/sdks/java",
                       "fr/developer-resources/sdks/kotlin",
-                      "fr/developer-resources/sdks/cli",
                       "fr/developer-resources/sdks/php",
                       "fr/developer-resources/sdks/csharp",
                       "fr/developer-resources/react-native-integration"
@@ -2686,6 +2685,7 @@
                       "fr/developer-resources/go-boilerplate"
                     ]
                   },
+                  "fr/developer-resources/sdks/cli",
                   "fr/developer-resources/overlay-checkout",
                   "fr/developer-resources/inline-checkout",
                   "fr/developer-resources/sentra",
@@ -3408,7 +3408,6 @@
                       "de/developer-resources/sdks/ruby",
                       "de/developer-resources/sdks/java",
                       "de/developer-resources/sdks/kotlin",
-                      "de/developer-resources/sdks/cli",
                       "de/developer-resources/sdks/php",
                       "de/developer-resources/sdks/csharp",
                       "de/developer-resources/react-native-integration"
@@ -3487,6 +3486,7 @@
                       "de/developer-resources/go-boilerplate"
                     ]
                   },
+                  "de/developer-resources/sdks/cli",
                   "de/developer-resources/overlay-checkout",
                   "de/developer-resources/inline-checkout",
                   "de/developer-resources/sentra",
@@ -4209,7 +4209,6 @@
                       "id/developer-resources/sdks/ruby",
                       "id/developer-resources/sdks/java",
                       "id/developer-resources/sdks/kotlin",
-                      "id/developer-resources/sdks/cli",
                       "id/developer-resources/sdks/php",
                       "id/developer-resources/sdks/csharp",
                       "id/developer-resources/react-native-integration"
@@ -4287,6 +4286,7 @@
                       "id/developer-resources/go-boilerplate"
                     ]
                   },
+                  "id/developer-resources/sdks/cli",
                   "id/developer-resources/overlay-checkout",
                   "id/developer-resources/inline-checkout",
                   "id/developer-resources/sentra",
@@ -5004,7 +5004,6 @@
                       "ja/developer-resources/sdks/ruby",
                       "ja/developer-resources/sdks/java",
                       "ja/developer-resources/sdks/kotlin",
-                      "ja/developer-resources/sdks/cli",
                       "ja/developer-resources/sdks/php",
                       "ja/developer-resources/sdks/csharp",
                       "ja/developer-resources/react-native-integration"
@@ -5083,6 +5082,7 @@
                       "ja/developer-resources/go-boilerplate"
                     ]
                   },
+                  "ja/developer-resources/sdks/cli",
                   "ja/developer-resources/overlay-checkout",
                   "ja/developer-resources/inline-checkout",
                   "ja/developer-resources/sentra",
@@ -5806,7 +5806,6 @@
                       "ko/developer-resources/sdks/ruby",
                       "ko/developer-resources/sdks/java",
                       "ko/developer-resources/sdks/kotlin",
-                      "ko/developer-resources/sdks/cli",
                       "ko/developer-resources/sdks/php",
                       "ko/developer-resources/sdks/csharp",
                       "ko/developer-resources/react-native-integration"
@@ -5884,6 +5883,7 @@
                       "ko/developer-resources/go-boilerplate"
                     ]
                   },
+                  "ko/developer-resources/sdks/cli",
                   "ko/developer-resources/overlay-checkout",
                   "ko/developer-resources/inline-checkout",
                   "ko/developer-resources/sentra",
@@ -6606,7 +6606,6 @@
                       "pt-BR/developer-resources/sdks/ruby",
                       "pt-BR/developer-resources/sdks/java",
                       "pt-BR/developer-resources/sdks/kotlin",
-                      "pt-BR/developer-resources/sdks/cli",
                       "pt-BR/developer-resources/sdks/php",
                       "pt-BR/developer-resources/sdks/csharp",
                       "pt-BR/developer-resources/react-native-integration"
@@ -6685,6 +6684,7 @@
                       "pt-BR/developer-resources/go-boilerplate"
                     ]
                   },
+                  "pt-BR/developer-resources/sdks/cli",
                   "pt-BR/developer-resources/overlay-checkout",
                   "pt-BR/developer-resources/inline-checkout",
                   "pt-BR/developer-resources/sentra",
@@ -7408,7 +7408,6 @@
                       "vi/developer-resources/sdks/ruby",
                       "vi/developer-resources/sdks/java",
                       "vi/developer-resources/sdks/kotlin",
-                      "vi/developer-resources/sdks/cli",
                       "vi/developer-resources/sdks/php",
                       "vi/developer-resources/sdks/csharp",
                       "vi/developer-resources/react-native-integration"
@@ -7487,6 +7486,7 @@
                       "vi/developer-resources/go-boilerplate"
                     ]
                   },
+                  "vi/developer-resources/sdks/cli",
                   "vi/developer-resources/overlay-checkout",
                   "vi/developer-resources/inline-checkout",
                   "vi/developer-resources/sentra",
@@ -8204,7 +8204,6 @@
                       "cn/developer-resources/sdks/ruby",
                       "cn/developer-resources/sdks/java",
                       "cn/developer-resources/sdks/kotlin",
-                      "cn/developer-resources/sdks/cli",
                       "cn/developer-resources/sdks/php",
                       "cn/developer-resources/sdks/csharp",
                       "cn/developer-resources/react-native-integration"
@@ -8283,6 +8282,7 @@
                       "cn/developer-resources/go-boilerplate"
                     ]
                   },
+                  "cn/developer-resources/sdks/cli",
                   "cn/developer-resources/overlay-checkout",
                   "cn/developer-resources/inline-checkout",
                   "cn/developer-resources/sentra",
@@ -9006,7 +9006,6 @@
                       "hi/developer-resources/sdks/ruby",
                       "hi/developer-resources/sdks/java",
                       "hi/developer-resources/sdks/kotlin",
-                      "hi/developer-resources/sdks/cli",
                       "hi/developer-resources/sdks/php",
                       "hi/developer-resources/sdks/csharp",
                       "hi/developer-resources/react-native-integration"
@@ -9085,6 +9084,7 @@
                       "hi/developer-resources/go-boilerplate"
                     ]
                   },
+                  "hi/developer-resources/sdks/cli",
                   "hi/developer-resources/overlay-checkout",
                   "hi/developer-resources/inline-checkout",
                   "hi/developer-resources/sentra",
@@ -9808,7 +9808,6 @@
                       "it/developer-resources/sdks/ruby",
                       "it/developer-resources/sdks/java",
                       "it/developer-resources/sdks/kotlin",
-                      "it/developer-resources/sdks/cli",
                       "it/developer-resources/sdks/php",
                       "it/developer-resources/sdks/csharp",
                       "it/developer-resources/react-native-integration"
@@ -9887,6 +9886,7 @@
                       "it/developer-resources/go-boilerplate"
                     ]
                   },
+                  "it/developer-resources/sdks/cli",
                   "it/developer-resources/overlay-checkout",
                   "it/developer-resources/inline-checkout",
                   "it/developer-resources/sentra",
@@ -10611,7 +10611,6 @@
                       "sv/developer-resources/sdks/ruby",
                       "sv/developer-resources/sdks/java",
                       "sv/developer-resources/sdks/kotlin",
-                      "sv/developer-resources/sdks/cli",
                       "sv/developer-resources/sdks/php",
                       "sv/developer-resources/sdks/csharp",
                       "sv/developer-resources/react-native-integration"
@@ -10690,6 +10689,7 @@
                       "sv/developer-resources/go-boilerplate"
                     ]
                   },
+                  "sv/developer-resources/sdks/cli",
                   "sv/developer-resources/overlay-checkout",
                   "sv/developer-resources/inline-checkout",
                   "sv/developer-resources/sentra",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -320,6 +320,18 @@ Speed up development with our official SDKs. Choose from our recommended languag
   <Card title="Ruby" icon="gem" href="/developer-resources/dodo-payments-sdks#ruby" />
 </CardGroup>
 
+### Dodo CLI
+
+Drive Dodo Payments from your terminal. The Dodo CLI ships with an interactive TUI, a built-in AI assistant, and offline webhook testing — install it in one line:
+
+```bash
+curl -fsSL https://dodopayments.com/install.sh | sh
+```
+
+<Card title="Dodo CLI" icon="terminal" href="/developer-resources/sdks/cli">
+  Manage payments, customers, and webhooks from your terminal — with a TUI, AI assistant, and real-time webhook listener built in.
+</Card>
+
 ### Billing SDK
 
 Stop reinventing the wheel. Use production-ready, accessible billing components, from pricing cards to subscription dashboards, built for React and ShadCN.


### PR DESCRIPTION
## Summary

Follow-up to the install.sh one-liner work ([dodopayments/dodo-website#239](https://github.com/dodopayments/dodo-website/pull/239)). Promotes the CLI to its own sidebar entry without moving the page.

1. **`install.sh` is now the primary install method** on the CLI page.
2. **Page renamed**: `"CLI"` → `"Dodo CLI"`.
3. **`NEW` tag** via page frontmatter (`tag: "NEW"` — same pattern as `customer-wallet`, `credit-based-billing`, `fastapi-boilerplate`, etc.).
4. **Lifted out of the SDKs group** in `docs.json` — now a top-level sibling page inside `Integrate`, slotted right after the **Boilerplates** group (before `overlay-checkout`, `inline-checkout`, `sentra`, etc.).
5. **Homepage mention** — a short `### Dodo CLI` subsection on `introduction.mdx` right after "Powerful SDKs".

## Scope (3 files)

- **`developer-resources/sdks/cli.mdx`** — title, description, `tag: "NEW"`, install.sh promoted to primary, Updates section adds installer re-run. Page path unchanged.
- **`docs.json`** — `"developer-resources/sdks/cli"` removed from the SDKs group, re-added as a bare page in Integrate right after Boilerplates. The 13 localized navs were regenerated via `scripts/addUpdateLanguage.ts` to mirror the same position.
- **`introduction.mdx`** — new `### Dodo CLI` subsection with the curl one-liner and a Card link.

No file moves. No redirects. No other internal-link rewrites.

## Translations

Only the English source `.mdx` files are touched. The 13 localized nav entries were rewritten by `scripts/addUpdateLanguage.ts` (the canonical workflow in this repo). The localized `developer-resources/sdks/cli.mdx` files keep their existing content; the Sync Languages workflow will retranslate them on its next run.

## Verification

- ✅ `mintlify broken-links`: success, no broken links.
- ✅ `docs.json` parses as valid JSON.
- ✅ The installer was end-to-end tested before opening the website PR — real `v3.1.0` darwin/arm64 binary downloaded from GitHub Releases, SHA-256 verified against `SHA256SUMS.txt`, `dodo --version` returned `v3.1.0`.

## Related

- Website PR adding the route: dodopayments/dodo-website#239 (must merge first so `dodopayments.com/install.sh` is live before this lands).