### PR TITLE
docs(accepted-countries): move policy notes to bottom of page

### DIFF
--- a/miscellaneous/accepted-countries-and-territories.mdx
+++ b/miscellaneous/accepted-countries-and-territories.mdx
@@ -5,20 +5,6 @@ icon: "globe"
 keywords: ["Dodo Payments", "accepted countries", "supported countries", "territories", "payouts"]
 ---
 
-<Note>
-This policy applies to all country designations made on or after March 23, 2026. Merchants receiving services in countries supported prior to this date will not be affected, unless the relevant country is subject to active sanctions or regulatory restrictions. In such cases, Dodo Payments reserves the right to discontinue support.
-</Note>
-
-<Note>
-This list is regularly updated to reflect FATF, OFAC, UN, and EU AML/CFT directives. All merchants are responsible for ensuring ongoing compliance.
-
-Payouts are supported only in the countries and regions listed above. If your country is not included, payouts are not currently available from that location.
-
-This list may change over time in line with regulatory and compliance requirements, and we're unable to offer payouts outside of the supported regions.
-
-Merchant accounts are supported only where KYC documentation is issued in the countries listed above.
-</Note>
-
 1. Afghanistan
 2. Albania
 3. Andorra
@@ -204,3 +190,17 @@ Merchant accounts are supported only where KYC documentation is issued in the co
 183. Wallis and Futuna
 184. Zambia
 185. Zimbabwe
+
+<Note>
+This policy applies to all country designations made on or after March 23, 2026. Merchants receiving services in countries supported prior to this date will not be affected, unless the relevant country is subject to active sanctions or regulatory restrictions. In such cases, Dodo Payments reserves the right to discontinue support.
+</Note>
+
+<Note>
+This list is regularly updated to reflect FATF, OFAC, UN, and EU AML/CFT directives. All merchants are responsible for ensuring ongoing compliance.
+
+Payouts are supported only in the countries and regions listed above. If your country is not included, payouts are not currently available from that location.
+
+This list may change over time in line with regulatory and compliance requirements, and we're unable to offer payouts outside of the supported regions.
+
+Merchant accounts are supported only where KYC documentation is issued in the countries listed above.
+</Note>


### PR DESCRIPTION
## Summary
- Moved the two policy `<Note>` callouts from the top to the bottom of the accepted countries page
- Country list remains unchanged

## Test plan
- [ ] Verify notes render correctly at the bottom of the page
- [ ] Confirm country list is unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)