### PR TITLE
feat(api-reference): add product collections endpoints

### DIFF
--- a/api-reference/payouts/get-payout-invoice.mdx
+++ b/api-reference/payouts/get-payout-invoice.mdx
@@ -1,6 +1,0 @@
----
-openapi: get /invoices/payouts/{payout_id}
-title: Get Payout Invoice
-description: Get a payout invoice PDF by Payout ID.
-keywords: ["Dodo Payments", "API reference", "REST API", "get payout invoice"]
----

--- a/api-reference/payouts/get-payout-invoice.mdx
+++ b/api-reference/payouts/get-payout-invoice.mdx
@@ -1,0 +1,6 @@
+---
+openapi: get /invoices/payouts/{payout_id}
+title: Get Payout Invoice
+description: Get a payout invoice PDF by Payout ID.
+keywords: ["Dodo Payments", "API reference", "REST API", "get payout invoice"]
+---

--- a/api-reference/product-collections/add-group-items.mdx
+++ b/api-reference/product-collections/add-group-items.mdx
@@ -1,0 +1,6 @@
+---
+openapi: post /product-collections/{id}/groups/{group_id}/items
+title: Add Products to Group
+description: Add one or more products to a group within a product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "add products to group"]
+---

--- a/api-reference/product-collections/archive-product-collection.mdx
+++ b/api-reference/product-collections/archive-product-collection.mdx
@@ -1,0 +1,6 @@
+---
+openapi: delete /product-collections/{id}
+title: Archive Product Collection
+description: Archive a product collection associated with your account.
+keywords: ["Dodo Payments", "API reference", "REST API", "archive product collection"]
+---

--- a/api-reference/product-collections/create-group.mdx
+++ b/api-reference/product-collections/create-group.mdx
@@ -1,0 +1,6 @@
+---
+openapi: post /product-collections/{id}/groups
+title: Create Product Collection Group
+description: Add a new group to a product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "create product collection group"]
+---

--- a/api-reference/product-collections/create-product-collection.mdx
+++ b/api-reference/product-collections/create-product-collection.mdx
@@ -1,0 +1,6 @@
+---
+openapi: post /product-collections
+title: Create Product Collection
+description: Create a new product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "create product collection"]
+---

--- a/api-reference/product-collections/delete-group-item.mdx
+++ b/api-reference/product-collections/delete-group-item.mdx
@@ -1,0 +1,6 @@
+---
+openapi: delete /product-collections/{id}/groups/{group_id}/items/{item_id}
+title: Delete Group Item
+description: Remove a product item from a product collection group.
+keywords: ["Dodo Payments", "API reference", "REST API", "delete group item"]
+---

--- a/api-reference/product-collections/delete-group.mdx
+++ b/api-reference/product-collections/delete-group.mdx
@@ -1,0 +1,6 @@
+---
+openapi: delete /product-collections/{id}/groups/{group_id}
+title: Delete Product Collection Group
+description: Delete a group from a product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "delete product collection group"]
+---

--- a/api-reference/product-collections/get-product-collection.mdx
+++ b/api-reference/product-collections/get-product-collection.mdx
@@ -1,0 +1,6 @@
+---
+openapi: get /product-collections/{id}
+title: Get Product Collection
+description: Get detailed information about a specific product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "get product collection"]
+---

--- a/api-reference/product-collections/list-product-collections.mdx
+++ b/api-reference/product-collections/list-product-collections.mdx
@@ -1,0 +1,6 @@
+---
+openapi: get /product-collections
+title: List Product Collections
+description: Get a list of all product collections associated with your account.
+keywords: ["Dodo Payments", "API reference", "REST API", "list product collections"]
+---

--- a/api-reference/product-collections/unarchive-product-collection.mdx
+++ b/api-reference/product-collections/unarchive-product-collection.mdx
@@ -1,0 +1,6 @@
+---
+openapi: post /product-collections/{id}/unarchive
+title: Unarchive Product Collection
+description: Unarchive a product collection associated with your account.
+keywords: ["Dodo Payments", "API reference", "REST API", "unarchive product collection"]
+---

--- a/api-reference/product-collections/update-group-item.mdx
+++ b/api-reference/product-collections/update-group-item.mdx
@@ -1,0 +1,6 @@
+---
+openapi: patch /product-collections/{id}/groups/{group_id}/items/{item_id}
+title: Update Group Item
+description: Update a product item within a product collection group.
+keywords: ["Dodo Payments", "API reference", "REST API", "update group item"]
+---

--- a/api-reference/product-collections/update-group.mdx
+++ b/api-reference/product-collections/update-group.mdx
@@ -1,0 +1,6 @@
+---
+openapi: patch /product-collections/{id}/groups/{group_id}
+title: Update Product Collection Group
+description: Update a group within a product collection.
+keywords: ["Dodo Payments", "API reference", "REST API", "update product collection group"]
+---

--- a/api-reference/product-collections/update-product-collection-images.mdx
+++ b/api-reference/product-collections/update-product-collection-images.mdx
@@ -1,0 +1,6 @@
+---
+openapi: put /product-collections/{id}/images
+title: Update Product Collection Images
+description: Update a product collection's images.
+keywords: ["Dodo Payments", "API reference", "REST API", "update product collection images"]
+---

--- a/api-reference/product-collections/update-product-collection.mdx
+++ b/api-reference/product-collections/update-product-collection.mdx
@@ -1,0 +1,6 @@
+---
+openapi: patch /product-collections/{id}
+title: Update Product Collection
+description: Update a product collection's details.
+keywords: ["Dodo Payments", "API reference", "REST API", "update product collection"]
+---

--- a/docs.json
+++ b/docs.json
@@ -498,6 +498,25 @@
                 ]
               },
               {
+                "group": "Product Collections",
+                "tag": "NEW",
+                "pages": [
+                  "api-reference/product-collections/list-product-collections",
+                  "api-reference/product-collections/create-product-collection",
+                  "api-reference/product-collections/get-product-collection",
+                  "api-reference/product-collections/update-product-collection",
+                  "api-reference/product-collections/archive-product-collection",
+                  "api-reference/product-collections/unarchive-product-collection",
+                  "api-reference/product-collections/update-product-collection-images",
+                  "api-reference/product-collections/create-group",
+                  "api-reference/product-collections/update-group",
+                  "api-reference/product-collections/delete-group",
+                  "api-reference/product-collections/add-group-items",
+                  "api-reference/product-collections/update-group-item",
+                  "api-reference/product-collections/delete-group-item"
+                ]
+              },
+              {
                 "group": "Addons",
                 "pages": [
                   "api-reference/addons/create-addon",
@@ -562,6 +581,7 @@
                 "group": "Payouts",
                 "pages": [
                   "api-reference/payouts/get-payouts",
+                  "api-reference/payouts/get-payout-invoice",
                   "api-reference/payouts/retrieve-breakup",
                   "api-reference/payouts/list-breakup-details",
                   "api-reference/payouts/download-breakup-csv"

--- a/docs.json
+++ b/docs.json
@@ -498,25 +498,6 @@
                 ]
               },
               {
-                "group": "Product Collections",
-                "tag": "NEW",
-                "pages": [
-                  "api-reference/product-collections/list-product-collections",
-                  "api-reference/product-collections/create-product-collection",
-                  "api-reference/product-collections/get-product-collection",
-                  "api-reference/product-collections/update-product-collection",
-                  "api-reference/product-collections/archive-product-collection",
-                  "api-reference/product-collections/unarchive-product-collection",
-                  "api-reference/product-collections/update-product-collection-images",
-                  "api-reference/product-collections/create-group",
-                  "api-reference/product-collections/update-group",
-                  "api-reference/product-collections/delete-group",
-                  "api-reference/product-collections/add-group-items",
-                  "api-reference/product-collections/update-group-item",
-                  "api-reference/product-collections/delete-group-item"
-                ]
-              },
-              {
                 "group": "Addons",
                 "pages": [
                   "api-reference/addons/create-addon",
@@ -621,6 +602,25 @@
                 "pages": [
                   "api-reference/misc/supported-countries",
                   "api-reference/misc/charge-subscriptions"
+                ]
+              },
+              {
+                "group": "Product Collections",
+                "tag": "NEW",
+                "pages": [
+                  "api-reference/product-collections/list-product-collections",
+                  "api-reference/product-collections/create-product-collection",
+                  "api-reference/product-collections/get-product-collection",
+                  "api-reference/product-collections/update-product-collection",
+                  "api-reference/product-collections/archive-product-collection",
+                  "api-reference/product-collections/unarchive-product-collection",
+                  "api-reference/product-collections/update-product-collection-images",
+                  "api-reference/product-collections/create-group",
+                  "api-reference/product-collections/update-group",
+                  "api-reference/product-collections/delete-group",
+                  "api-reference/product-collections/add-group-items",
+                  "api-reference/product-collections/update-group-item",
+                  "api-reference/product-collections/delete-group-item"
                 ]
               }
             ]

--- a/docs.json
+++ b/docs.json
@@ -562,7 +562,6 @@
                 "group": "Payouts",
                 "pages": [
                   "api-reference/payouts/get-payouts",
-                  "api-reference/payouts/get-payout-invoice",
                   "api-reference/payouts/retrieve-breakup",
                   "api-reference/payouts/list-breakup-details",
                   "api-reference/payouts/download-breakup-csv"

--- a/features/product-collections.mdx
+++ b/features/product-collections.mdx
@@ -202,11 +202,7 @@ Plan changes via Customer Portal are disabled by default. Enable "Allow Subscrip
 
 ## Managing Collections
 
-Product Collections are created and managed exclusively through the Dodo Payments dashboard.
-
-<Info>
-Creating, updating, and deleting collections is only available via the dashboard. The API provides read-only access to retrieve collection data for integration purposes.
-</Info>
+Product Collections can be managed either through the Dodo Payments dashboard or programmatically via API. The API provides full control over collection creation, updates, image uploads, archiving, and managing nested groups and products.
 
 ### Dashboard Operations
 
@@ -214,7 +210,7 @@ Creating, updating, and deleting collections is only available via the dashboard
 - **Update**: Modify name, description, image, and product organization
 - **Reorder**: Drag and drop to change product display order
 - **Enable/Disable products**: Control which products appear in checkout
-- **Delete**: Remove a collection (products remain but are unlinked)
+- **Archive**: Hide a collection without permanently deleting it (can be unarchived later)
 
 <Frame>
   <img 
@@ -222,6 +218,112 @@ Creating, updating, and deleting collections is only available via the dashboard
     alt="Screenshot of the Product Collection dashboard showing the collection management operations" 
   style={{ maxHeight: '500px', width: 'auto' }} />
 </Frame>
+
+### API Management
+
+The following endpoints allow you to create, update, retrieve, archive, and organize product collections programmatically — including managing nested groups and the products within them.
+
+<AccordionGroup>
+<Accordion title="Listing Product Collections">
+Fetch all product collections associated with your account using a `GET` request to the `/product-collections` endpoint. Supports pagination, filtering by brand, and including archived collections.
+
+<Card title="List Product Collections API" icon="code" href="/api-reference/product-collections/list-product-collections">
+  View detailed request and response structure in the List Product Collections API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Creating a Product Collection">
+Create a new product collection by sending a `POST` request to the `/product-collections` endpoint with details such as name, description, and brand.
+
+<Card title="Create Product Collection API" icon="code" href="/api-reference/product-collections/create-product-collection">
+  View detailed request and response structure in the Create Product Collection API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Retrieving a Product Collection">
+Get detailed information about a specific product collection — including its groups and product items — using a `GET` request to the `/product-collections/{id}` endpoint.
+
+<Card title="Get Product Collection API" icon="code" href="/api-reference/product-collections/get-product-collection">
+  View detailed request and response structure in the Get Product Collection API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Updating a Product Collection">
+Modify a product collection's details (name, description, brand, etc.) by sending a `PATCH` request to the `/product-collections/{id}` endpoint.
+
+<Card title="Update Product Collection API" icon="code" href="/api-reference/product-collections/update-product-collection">
+  View detailed request and response structure in the Update Product Collection API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Uploading Collection Images">
+Associate an image with a collection by uploading it via a pre-signed URL. Request an upload URL from the `/product-collections/{id}/images` endpoint, then `PUT` the image to the returned URL within 60 seconds.
+
+<Warning>
+The pre-signed URL expires in 60 seconds, so the image must be uploaded within that timeframe.
+</Warning>
+
+<Card title="Update Collection Images API" icon="code" href="/api-reference/product-collections/update-product-collection-images">
+  View detailed request and response structure in the Update Collection Images API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Archiving a Product Collection">
+Archive a collection by sending a `DELETE` request to the `/product-collections/{id}` endpoint. This hides the collection from new use but does not permanently remove it.
+
+<Card title="Archive Product Collection API" icon="code" href="/api-reference/product-collections/archive-product-collection">
+  View detailed request and response structure in the Archive Product Collection API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Unarchiving a Product Collection">
+Restore an archived collection by sending a `POST` request to the `/product-collections/{id}/unarchive` endpoint.
+
+<Card title="Unarchive Product Collection API" icon="code" href="/api-reference/product-collections/unarchive-product-collection">
+  View detailed request and response structure in the Unarchive Product Collection API documentation.
+</Card>
+</Accordion>
+
+<Accordion title="Managing Groups within a Collection">
+Groups let you organize products inside a collection (for example, "Monthly Plans" vs. "Annual Plans"). Use the groups endpoints to add, update, or remove groups within a collection.
+
+- **Create a group**: `POST /product-collections/{id}/groups`
+- **Update a group**: `PATCH /product-collections/{id}/groups/{group_id}`
+- **Delete a group**: `DELETE /product-collections/{id}/groups/{group_id}`
+
+<CardGroup cols={3}>
+<Card title="Create Group" icon="code" href="/api-reference/product-collections/create-group">
+  Add a new group to a product collection.
+</Card>
+<Card title="Update Group" icon="code" href="/api-reference/product-collections/update-group">
+  Modify a group's name or attributes.
+</Card>
+<Card title="Delete Group" icon="code" href="/api-reference/product-collections/delete-group">
+  Remove a group from a collection.
+</Card>
+</CardGroup>
+</Accordion>
+
+<Accordion title="Managing Products within a Group">
+Manage the individual product items inside a group — add new products, update existing items (such as display order), or remove them entirely.
+
+- **Add products to a group**: `POST /product-collections/{id}/groups/{group_id}/items`
+- **Update a group item**: `PATCH /product-collections/{id}/groups/{group_id}/items/{item_id}`
+- **Delete a group item**: `DELETE /product-collections/{id}/groups/{group_id}/items/{item_id}`
+
+<CardGroup cols={3}>
+<Card title="Add Products to Group" icon="code" href="/api-reference/product-collections/add-group-items">
+  Add one or more products to a group within a collection.
+</Card>
+<Card title="Update Group Item" icon="code" href="/api-reference/product-collections/update-group-item">
+  Update a product item within a group.
+</Card>
+<Card title="Delete Group Item" icon="code" href="/api-reference/product-collections/delete-group-item">
+  Remove a product item from a group.
+</Card>
+</CardGroup>
+</Accordion>
+</AccordionGroup>
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

Documents the new **Product Collections** endpoints already present in `openapi/openapi.documented.yml`, covering full CRUD on collections plus nested groups and items:

- `GET/POST /product-collections`
- `GET/PATCH/DELETE /product-collections/{id}`
- `POST /product-collections/{id}/unarchive`
- `PUT /product-collections/{id}/images`
- `POST/PATCH/DELETE /product-collections/{id}/groups[/{group_id}]`
- `POST/PATCH/DELETE /product-collections/{id}/groups/{group_id}/items[/{item_id}]`

## Changes

- Adds `api-reference/product-collections/` with 13 endpoint stubs (one `.mdx` per operation), each delegating to the OpenAPI spec via `openapi:` frontmatter.
- Updates `docs.json` (English navigation only) to add a new **Product Collections** group (tagged `NEW`) at the end of the API Reference nav, after **Miscellaneous**.
- Updates `features/product-collections.mdx` to replace the outdated \"API is read-only\" note with a full **API Management** section (collapsible accordions in the same style as `features/products.mdx`) linking to each new endpoint.

## Notes

- Per repo convention, each `.mdx` is a thin stub that points at the OpenAPI operation via the `openapi:` frontmatter — Mintlify renders the full reference from the spec.
- Translated locales (\`ar\`, \`cn\`, \`de\`, \`es\`, \`fr\`, \`hi\`, \`id\`, \`it\`, \`ja\`, \`ko\`, \`pt-BR\`, \`sv\`, \`vi\`) are intentionally left untouched; the i18n pipeline will pick up the new pages.

### Deferred: payout invoice endpoint

An earlier commit on this branch added a stub for \`GET /invoices/payouts/{payout_id}\` under the Payouts nav group, but it was removed before merge. Reasons for deferring:

- The endpoint is tagged \`Invoices\` (not \`Payouts\`) in the OpenAPI spec, so placing it in the Payouts group would be a categorisation mismatch.
- Its OpenAPI \`operationId\` is \`get_payout_invoice_no_auth\` — the \`_no_auth\` suffix suggests it may be a public/unauthenticated endpoint that needs separate treatment from the authenticated API reference.

It can be added in a follow-up PR once the right nav placement and auth story are decided.