### PR TITLE
docs: document cancellation flow for on-demand subscriptions

### DIFF
--- a/developer-resources/ondemand-subscriptions.mdx
+++ b/developer-resources/ondemand-subscriptions.mdx
@@ -438,6 +438,89 @@ Only retry on soft/temporary issues (e.g., `insufficient_funds`, `issuer_unavail
 - Communicate proactively: email/SMS the customer to update their payment method before the next scheduled attempt.
 - Use metadata only for observability (e.g., `retry_attempt`); never try to "evade" fraud/risk systems by rotating inconsequential fields.
 
+## Cancellation
+
+On-demand subscriptions follow a different cancellation flow from scheduled subscriptions because there is no fixed billing cycle to anchor an immediate end date.
+
+### Customer portal behavior
+
+When a customer cancels an on-demand subscription from the [Customer Portal](/features/customer-portal), the cancellation is **scheduled for the next billing date** by default. The **Cancel Now** option is intentionally not shown for on-demand subscriptions.
+
+The reason: on-demand subscriptions do not have predictable recurring renewal dates — the next charge time is driven entirely by your usage events. Scheduling cancellation at the next billing date keeps the mandate active until the period boundary so any in-flight usage can still be charged, then ends the subscription cleanly.
+
+After the customer confirms cancellation:
+- The subscription stays `active` and remains chargeable via `POST /subscriptions/{id}/charge` until the scheduled cancellation date.
+- `cancel_at_next_billing_date` is set to `true` on the subscription.
+- A `subscription.cancelled` webhook is emitted when the cancellation takes effect.
+
+<Info>
+If you need to end the subscription immediately (for example, in response to a refund or a support request), cancel it programmatically via the API instead of relying on the customer portal flow.
+</Info>
+
+### Cancel programmatically
+
+You can cancel an on-demand subscription via the API at any time. You control whether the cancellation is immediate or scheduled.
+
+Endpoint: [PATCH /subscriptions/\{subscription_id\}](/api-reference/subscriptions/update-subscription)
+
+<Tabs>
+<Tab title="Cancel immediately">
+
+Set the subscription `status` to `cancelled` to end it right away. The mandate is revoked and no further charges can be created.
+
+```javascript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({ bearerToken: process.env.DODO_PAYMENTS_API_KEY });
+
+await client.subscriptions.update('sub_123', {
+  status: 'cancelled',
+});
+```
+
+```bash cURL
+curl -X PATCH "$DODO_API/subscriptions/sub_123" \
+  -H "Authorization: Bearer $DODO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "status": "cancelled" }'
+```
+
+</Tab>
+<Tab title="Cancel at next billing date">
+
+Mirror the customer portal behavior — keep the subscription active until the scheduled cancellation date, then end it.
+
+```javascript
+import DodoPayments from 'dodopayments';
+
+const client = new DodoPayments({ bearerToken: process.env.DODO_PAYMENTS_API_KEY });
+
+await client.subscriptions.update('sub_123', {
+  cancel_at_next_billing_date: true,
+});
+```
+
+```bash cURL
+curl -X PATCH "$DODO_API/subscriptions/sub_123" \
+  -H "Authorization: Bearer $DODO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "cancel_at_next_billing_date": true }'
+```
+
+</Tab>
+</Tabs>
+
+### Webhooks on cancellation
+
+| Event | When it fires |
+|-------|---------------|
+| `subscription.cancelled` | Subscription is fully cancelled and no longer chargeable |
+| `subscription.plan_changed` | `cancel_at_next_billing_date` was toggled (scheduled cancellation set or undone) |
+
+<Tip>
+To distinguish on-demand cancellations from scheduled-subscription cancellations in your handler, check the subscription's `on_demand` flag when processing the webhook.
+</Tip>
+
 ## Track outcomes with webhooks
 
 Implement webhook handling to track the customer journey. See [Implementing Webhooks](/developer-resources/integration-guide#implementing-webhooks).
@@ -445,6 +528,7 @@ Implement webhook handling to track the customer journey. See [Implementing Webh
 - **subscription.active**: Mandate authorized and subscription activated
 - **subscription.failed**: Creation failed (e.g., mandate failure)
 - **subscription.on_hold**: Subscription placed on hold (e.g., unpaid state)
+- **subscription.cancelled**: Subscription fully cancelled (see [Cancellation](#cancellation))
 - **payment.succeeded**: Charge succeeded
 - **payment.failed**: Charge failed
 


### PR DESCRIPTION
## Summary

Addresses #282 by adding a dedicated **Cancellation** section to the on-demand subscriptions guide (`developer-resources/ondemand-subscriptions.mdx`).

The reporter noted that on-demand subscriptions don't show a "Cancel Now" option in the customer portal and defaults to "cancel at next billing cycle", but this behavior wasn't documented.

## Changes

- Added **Customer portal behavior** subsection explaining *why* the "Cancel Now" option isn't shown for on-demand subscriptions (no predictable recurring renewal date — next charge is driven by usage events), and clarifying the subscription stays chargeable until the scheduled cancellation date.
- Added **Cancel programmatically** subsection with tabbed Node SDK + cURL examples for:
  - Cancel immediately (`status: 'cancelled'`)
  - Cancel at next billing date (`cancel_at_next_billing_date: true`)
- Added **Webhooks on cancellation** table covering `subscription.cancelled` and `subscription.plan_changed`.
- Added `subscription.cancelled` to the existing webhook list in the "Track outcomes with webhooks" section.

Closes #282

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/e0967741ebb228d06a8894e4eee1b423)*