### PR TITLE
docs(changelog): add v1.99.0 to version logs table

### DIFF
--- a/changelog/introduction.mdx
+++ b/changelog/introduction.mdx
@@ -10,6 +10,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates"]
 
 | Version | Release Date | Highlights |
 |---------|--------------|------------|
+| [v1.99.0](/changelog/v1.99.0) | May 25, 2026 | Stacked discount codes (up to 20 per checkout, payment, or subscription), seven new customer notification emails for refunds and subscription lifecycle events, Sunbit BNPL for US customers, checkout payment page overhaul lifting success rates by 2–3%, product form rework with live preview and autosave, and Business Settings redesign |
 | [v1.97.6](/changelog/v1.97.6) | May 7, 2026 | Entitlements launch with five new fulfilment integrations (Discord, GitHub, Telegram, Framer, Notion), subscription cancellation reasons in the customer portal, configurable INR e-mandate floor, adaptive currency fees inclusive setting, Dodo Payments Desktop app for macOS/Windows/Linux, stablecoin payments (USDC/USDP/USDG), import existing license keys, and require_phone_number for checkout sessions |
 | [v1.94.0](/changelog/v1.94.0) | April 8, 2026 | Abandoned Cart Recovery, Subscription Dunning, discount metadata, recovery webhooks, Pix payments for Brazil, and WeChat Pay for Chinese customers |
 | [v1.93.0](/changelog/v1.93.0) | March 28, 2026 | Checkout redesign with improved loading states, net revenue analytics, business-level payment method disabling, payout breakdown, Visa RDR configuration, DoNotBill proration mode, scheduled plan changes, and delete customer payment method API |


### PR DESCRIPTION
## Summary

- The Changelog introduction page (`changelog/introduction.mdx`) was missing the latest release `v1.99.0` (May 25, 2026) in its Version Logs table — even though the underlying `changelog/v1.99.0.mdx` page and `docs.json` navigation entry already exist.
- Adds `v1.99.0` as the first row of the table with the release-page description.

## Scope

- English changelog intro only. The localized intro pages (`ko/`, `es/`, etc.) are independently behind on multiple prior releases and appear to be maintained by a separate translation pipeline — not touched here.