### PR TITLE
docs(checkout): reference minimal_address in Smart Address Collection

### DIFF
--- a/features/checkout.mdx
+++ b/features/checkout.mdx
@@ -197,6 +197,33 @@ The checkout supports flexible address entry for faster completion.
 Address collection balances speed, accuracy, and global coverage to maximize conversion while ensuring compliance.
 </Tip>
 
+### Minimal Address Mode
+
+For maximum conversion, enable minimal address collection to reduce checkout friction. When `minimal_address` is set to `true`, the checkout only collects:
+
+- **Country** — always required for tax determination
+- **ZIP/Postal code** — only in regions where it's necessary for sales tax, VAT, or GST calculation
+
+All other address fields (street, city, state) are skipped, significantly speeding up checkout completion.
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [
+    { product_id: 'prod_abc', quantity: 1 }
+  ],
+  minimal_address: true,
+  return_url: 'https://yoursite.com/return'
+});
+```
+
+<Info>
+Full address collection remains the default. Enable `minimal_address` for digital products and SaaS flows where complete billing details aren't required.
+</Info>
+
+<Card title="Minimal Address Reference" icon="address-card" href="/developer-resources/checkout-session#request-body">
+  See the full `minimal_address` parameter reference in the Checkout Sessions API guide.
+</Card>
+
 ## Phone Number Collection
 
 Control whether the phone number field appears on checkout — and whether it's required — using checkout session feature flags.

--- a/features/checkout.mdx
+++ b/features/checkout.mdx
@@ -206,6 +206,10 @@ For maximum conversion, enable minimal address collection to reduce checkout fri
 
 All other address fields (street, city, state) are skipped, significantly speeding up checkout completion.
 
+<Frame>
+  <img src="/images/changelog/minimal-address.png" alt="Minimal address mode showing only country and ZIP/postal code fields on checkout" style={{ maxHeight: '500px', width: 'auto' }} />
+</Frame>
+
 ```typescript
 const session = await client.checkoutSessions.create({
   product_cart: [

--- a/features/checkout.mdx
+++ b/features/checkout.mdx
@@ -192,6 +192,7 @@ The checkout supports flexible address entry for faster completion.
 | **Google Address Autofill** | Quick selection with autocomplete |
 | **Manual Entry** | Full control for complete addresses |
 | **Country Selection** | Drives tax and compliance logic |
+| **Minimal Address** | Collect only country (and ZIP where required for tax) — see [Minimal Address Mode](#minimal-address-mode) |
 
 <Tip>
 Address collection balances speed, accuracy, and global coverage to maximize conversion while ensuring compliance.


### PR DESCRIPTION
## Summary

- Add a **Minimal Address Mode** subsection to `features/checkout.mdx` under the existing Smart Address Collection section so the conversion-focused checkout overview surfaces the `minimal_address` option (previously only documented in the Checkout Sessions API guide and the v1.66.0 changelog).
- Include a short TypeScript example showing `minimal_address: true` in a `checkoutSessions.create` call, plus a `Card` link back to the full parameter reference in `/developer-resources/checkout-session#request-body`.

## Scope

- English only: changes limited to `features/checkout.mdx`. Translated locale files are intentionally left untouched and will be picked up by the existing translation sync workflow.

## Why

`minimal_address` is a high-impact conversion lever, but the main Checkout Features page didn't mention it — readers had to discover it through the API reference or changelog. Surfacing it next to the other address collection options makes the option discoverable at the right point in the docs journey.