### PR TITLE
docs(features): add new adaptive currencies (JPY, KRW, VND, PYG, XAF, XOF)

### DIFF
--- a/features/adaptive-currency.mdx
+++ b/features/adaptive-currency.mdx
@@ -131,7 +131,7 @@ INR → INR transactions are always treated as inclusive regardless of the busin
 | DOP | Dominican Peso | Dominican Republic | 100.00 DOP |
 | EGP | Egyptian Pound | Egypt | 50.00 EGP |
 | ETB | Ethiopian Birr | Ethiopia | 100.00 ETB |
-| EUR | Euro | Austria, Belgium, Cyprus, Estonia, Finland, France, Germany, Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, Portugal, Slovakia, Slovenia, Spain, Andorra, San Marino, Montenegro | 0.50 EUR |
+| EUR | Euro | Austria, Belgium, Cyprus, Estonia, Finland, France, Germany, Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, Portugal, Slovakia, Slovenia, Spain, Andorra, Monaco, Croatia, San Marino, Montenegro | 0.50 EUR |
 | FJD | Fijian Dollar | Fiji | 2.00 FJD |
 | GBP | British Pound | United Kingdom | 0.30 GBP |
 | GEL | Georgian Lari | Georgia | 3.00 GEL |
@@ -144,6 +144,8 @@ INR → INR transactions are always treated as inclusive regardless of the busin
 | IDR | Indonesian Rupiah | Indonesia | 8500.00 IDR |
 | ILS | Israeli New Shekel | Israel | 3.00 ILS |
 | INR | Indian Rupee | India | 5.00 INR |
+| JPY | Japanese Yen | Japan | 50 JPY |
+| KRW | South Korean Won | South Korea | 50 KRW |
 | KZT | Kazakhstani Tenge | Kazakhstan | 500.00 KZT |
 | LKR | Sri Lankan Rupee | Sri Lanka | 300.00 LKR |
 | LRD | Liberian Dollar | Liberia | 200.00 LRD |
@@ -164,6 +166,7 @@ INR → INR transactions are always treated as inclusive regardless of the busin
 | PGK | Papua New Guinean Kina | Papua New Guinea | 4.00 PGK |
 | PHP | Philippine Peso | Philippines | 50.00 PHP |
 | PLN | Polish Zloty | Poland | 2.00 PLN |
+| PYG | Paraguayan Guaraní | Paraguay | 4000 PYG |
 | QAR | Qatari Rial | Qatar | 3.00 QAR |
 | RON | Romanian Leu | Romania | 2.00 RON |
 | RSD | Serbian Dinar | Serbia | 60.00 RSD |
@@ -179,7 +182,10 @@ INR → INR transactions are always treated as inclusive regardless of the busin
 | TWD | New Taiwan Dollar | Taiwan | 20.00 TWD |
 | TZS | Tanzanian Shilling | Tanzania | 3000.00 TZS |
 | UYU | Uruguayan Peso | Uruguay | 50.00 UYU |
+| VND | Vietnamese Dong | Vietnam | 12000 VND |
 | WST | Samoan Tala | Samoa | 2.00 WST |
+| XAF | Central African CFA Franc | Cameroon, Central African Republic, Chad, Republic of the Congo, Equatorial Guinea, Gabon | 300 XAF |
+| XOF | West African CFA Franc | Benin, Burkina Faso, Côte d'Ivoire, Guinea-Bissau, Mali, Niger, Senegal, Togo | 300 XOF |
 | ZAR | South African Rand | South Africa | 20.00 ZAR |
 | ZMW | Zambian Kwacha | Zambia | 30.00 ZMW |
 


### PR DESCRIPTION
## What

Syncs the **Supported Currencies** table on the [Adaptive Currency](https://docs.dodopayments.com/features/adaptive-currency) page with the backend source of truth.

Source of truth: `get_adaptive_currency_from_country` (country → currency auto-detection) and `get_minimum_amount` (chargeable currencies + minimums) in `crates/public/src/routes/payments/payments_create.rs`.

## Added currencies

| Code | Name | Countries | Minimum |
|------|------|-----------|---------|
| JPY | Japanese Yen | Japan | 50 JPY |
| KRW | South Korean Won | South Korea | 50 KRW |
| VND | Vietnamese Dong | Vietnam | 12000 VND |
| PYG | Paraguayan Guaraní | Paraguay | 4000 PYG |
| XAF | Central African CFA Franc | Cameroon, Central African Republic, Chad, Republic of the Congo, Equatorial Guinea, Gabon | 300 XAF |
| XOF | West African CFA Franc | Benin, Burkina Faso, Côte d'Ivoire, Guinea-Bissau, Mali, Niger, Senegal, Togo | 300 XOF |

These are zero-decimal currencies, so minimums are shown without decimal points (matching the backend display strings).

Also added **Monaco** and **Croatia** to the EUR country list to match the backend mapping (Croatia adopted the Euro in 2023).

## Out of scope — flagged for follow-up

The backend shows two existing rows are now stale, but they are **removals/corrections** rather than additions, so they are intentionally left out of this PR:

- **ARS (Argentina)** — now a removed/unsupported currency (no `get_minimum_amount` entry; Argentina auto-maps to USD). Listing it under "Supported Currencies" is no longer accurate.
- **CLP (Chile)** — Chile no longer auto-maps to CLP (falls back to USD), and CLP is now zero-decimal with a `500 CLP` minimum (the page currently shows `1000.00 CLP`).

Let me know if you'd like a follow-up PR to correct/remove these.

## Notes

- Only the English source `features/adaptive-currency.mdx` is edited. Translated language folders are regenerated automatically (per `AGENTS.md`) and are not touched here.
- No `docs.json` change needed — the page already exists and is registered.
- Validated with `mintlify broken-links`; no errors on the edited page.