### PR TITLE
docs(changelog): add v1.105.0 release notes

### DIFF
--- a/changelog/v1.105.0.mdx
+++ b/changelog/v1.105.0.mdx
@@ -119,7 +119,7 @@ Tax ID validation at checkout has been extended with **notation detection and re
 
 ### 11. **Analytics Improvements**
 
-Dashboard analytics have been migrated to the **v2.1** endpoints, with corrected subscription MRR, active-subscription counts, and retention/churn calculations.
+Dashboard analytics now include corrected subscription MRR, active-subscription counts, and retention/churn calculations.
 
 <Frame>
 <img src="/images/analytics/revenue-breakdown.png" alt="Revenue analytics with a gross/net toggle and an MRR breakdown" style={{ maxHeight: '500px', width: 'auto' }} />


### PR DESCRIPTION
## Summary

Adds the `v1.105.0` changelog entry and registers it in the changelog index/navigation.

This is a follow-up to the earlier changelog branch work and includes the final public-facing copy cleanup requested after PR #359: removing the internal "v2.1 endpoints" analytics wording.

## Highlights

- Adds `changelog/v1.105.0.mdx` with prioritized release notes.
- Adds `v1.105.0` to `changelog/introduction.mdx`.
- Registers `changelog/v1.105.0` in `docs.json` under June 2026.
- Includes major items: BYOP, Rust SDK release, Korean wallets + Przelewy24, `brand_id` on webhooks, decimal-aware currency handling, entitlement limit increases, signed customer credits, card details on List Payments, branded recovery emails, tax ID validation, analytics improvements, and dashboard/storefront polish.

## Excluded / removed

- No biweekly or tri-weekly payout cycle documentation.
- No Dynamic Cardholder Name changelog item.
- No BYOP `0.5% usage fee` bullet.
- No internal "Dashboard analytics migrated to v2.1 endpoints" wording.
- No Brazil/Portugal tax, `UNKNOWN_ERROR`, or concurrent renewal-locking bullets.

## Verification

- `docs.json` parses as valid JSON.
- Removed/internal wording does not appear in the changelog.
- No `biweekly` / `tri-weekly` references remain in English source docs.
- All internal changelog links resolve to real `.mdx` pages.
- All referenced changelog images exist.
- `mintlify broken-links` could not run locally because the installed CLI rejects Node 26 (`mintlify is not supported on node versions 25+`).
