### PR TITLE
docs(feature-request): migrate feedback portal to feedback.dodopayments.com

### DIFF
--- a/features/feature-request.mdx
+++ b/features/feature-request.mdx
@@ -1,24 +1,24 @@
 ---
 title: Feature Request and Roadmap
-description: We value feedback from our merchants and aim to continuously improve Dodo Payments to meet your business needs. Submit feature requests, vote on existing ideas, and track our public roadmap through Featurebase.
+description: We value feedback from our merchants and aim to continuously improve Dodo Payments to meet your business needs. Submit feature requests, vote on existing ideas, and track our public roadmap through our feedback portal.
 icon: "lightbulb"
 keywords: ["Dodo Payments", "feature request and roadmap", "payment platform", "SaaS billing"]
 ---
 
-We use [Featurebase](https://dodopayments.featurebase.app/) to manage feature requests and maintain our public roadmap. This platform allows you to submit ideas, vote on features you'd like to see, and track the development status of upcoming improvements.
+We use our [feedback portal](https://feedback.dodopayments.com/) to manage feature requests and maintain our public roadmap. This platform allows you to submit ideas, vote on features you'd like to see, and track the development status of upcoming improvements.
 
-<Card title="Visit Our Public Roadmap" icon="external-link" href="https://dodopayments.featurebase.app/">
-View all feature requests, vote on ideas, and track our product roadmap on Featurebase.
+<Card title="Visit Our Public Roadmap" icon="external-link" href="https://feedback.dodopayments.com/">
+View all feature requests, vote on ideas, and track our product roadmap on our feedback portal.
 </Card>
 
 ## **Request a New Feature**
 
-If you have an idea for a feature that would enhance your experience with Dodo Payments, you can submit a feature request directly on Featurebase.
+If you have an idea for a feature that would enhance your experience with Dodo Payments, you can submit a feature request directly on our feedback portal.
 
 <img src="/images/feature-request/Feature.png" alt="Feature Request" style={{ maxHeight: '500px', width: 'auto' }} />
 
 - **How to Request a Feature**:
-    1. Visit our [Featurebase portal](https://dodopayments.featurebase.app/).
+    1. Visit our [feedback portal](https://feedback.dodopayments.com/).
     2. Click on **"Post an idea"** or **"Submit a feature request"**.
     3. Provide the following details:
         - **Feature Name**: A concise title for your feature idea.
@@ -32,10 +32,10 @@ If you have an idea for a feature that would enhance your experience with Dodo P
 
 ## **Vote for Existing Feature Requests**
 
-We prioritize features that benefit the most merchants. You can browse existing feature requests on Featurebase and vote for those you find valuable.
+We prioritize features that benefit the most merchants. You can browse existing feature requests on our feedback portal and vote for those you find valuable.
 
 - **How to Vote**:
-    1. Visit our [Featurebase portal](https://dodopayments.featurebase.app/).
+    1. Visit our [feedback portal](https://feedback.dodopayments.com/).
     2. Browse through the list of submitted requests.
     3. Click the **upvote** button (👍) next to the feature(s) you support.
 - **Benefits of Voting**:
@@ -45,18 +45,18 @@ We prioritize features that benefit the most merchants. You can browse existing 
 
 ## **View the Product Roadmap**
 
-Stay informed about the status of feature development through our public roadmap on Featurebase.
+Stay informed about the status of feature development through our public roadmap.
 
 - **Roadmap Features**:
     - **Planned**: Features that have been approved and are scheduled for development.
     - **In Progress**: Features currently being worked on by our team.
     - **Completed**: Features that have been successfully implemented and are live.
 - **How to Access**:
-    - Visit our [Featurebase portal](https://dodopayments.featurebase.app/).
+    - Visit our [feedback portal](https://feedback.dodopayments.com/).
     - Navigate to the **Roadmap** section to view features by status.
     - Browse the feature categories and their current statuses.
     - Filter by status, category, or search for specific features.
 
 <Tip>
-Bookmark our [Featurebase portal](https://dodopayments.featurebase.app/) to stay updated on new features and vote on ideas that matter to you.
+Bookmark our [feedback portal](https://feedback.dodopayments.com/) to stay updated on new features and vote on ideas that matter to you.
 </Tip>


### PR DESCRIPTION
## What

We've moved our public feedback portal from Featurebase (`dodopayments.featurebase.app`) to our own domain at [feedback.dodopayments.com](https://feedback.dodopayments.com/).

This updates the **Feature Request and Roadmap** page to point all links and references to the new portal.

## Changes

- `features/feature-request.mdx`
  - Replaced all 6 `https://dodopayments.featurebase.app/` links with `https://feedback.dodopayments.com/`.
  - Rebranded "Featurebase" mentions to "our feedback portal" (the description, intro, card, and section copy), since we've moved off Featurebase.

## Scope notes

- **Changelog left untouched** (`changelog/v1.61.5.mdx`, `changelog/introduction.mdx`): these are point-in-time historical records of the v1.61.5 release (Nov 17, 2025) when the Featurebase integration originally shipped. Rewriting them would misrepresent history.
- **Language folders not edited**: `ar/ cn/ de/ es/ fr/ hi/ id/ it/ ja/ ko/ pt-BR/ sv/ vi/` are machine-translated and regenerated via lingo.dev from the English source — they'll pick up this change on the next sync.

## Verification

- Confirmed `https://feedback.dodopayments.com/` returns 200.
- Confirmed no `featurebase` references remain in the edited file.