### PR TITLE
feat: add "Ask AI" (Sentra) docs assistant loader

### DIFF
--- a/assistant-loader.js
+++ b/assistant-loader.js
@@ -1,0 +1,37 @@
+// Dodo Payments docs — "Ask AI" assistant loader.
+//
+// Mintlify auto-injects every root-level `.js` file on every page (same mechanism that
+// loads `seo.js`). This file injects the self-owned chat widget bundle and its config.
+// The widget bundle itself is served from the private Cloudflare Worker, NOT this repo,
+// so no heavy JS or secrets live here — only the public endpoint + Turnstile sitekey.
+(function () {
+  if (typeof window === "undefined" || typeof document === "undefined") return;
+
+  var WIDGET_SRC = "https://chat.dodopayments.com/widget.js";
+  var SCRIPT_ID = "dodo-assistant-widget-script";
+
+  // Config consumed by widget.js (the `window.DodoAssistant` contract).
+  // turnstileSitekey is a PUBLIC key (safe to ship to the browser); the matching
+  // secret key never leaves the Worker.
+  window.DodoAssistant = {
+    chatEndpoint: "https://chat.dodopayments.com/chat",
+    turnstileSitekey: "0x4AAAAAADrfVZLFta7tMqJJ",
+    starterQuestions: [
+      "How do I create a subscription?",
+      "How do I integrate Checkout?",
+      "Which payment methods are supported?",
+      "How do webhooks work?",
+    ],
+    hotkey: "mod+i",
+  };
+
+  // Idempotent across Mintlify SPA navigations: if the loader runs again, don't
+  // re-inject the bundle. (The widget also guards against duplicate hosts.)
+  if (document.getElementById(SCRIPT_ID)) return;
+
+  var s = document.createElement("script");
+  s.id = SCRIPT_ID;
+  s.src = WIDGET_SRC;
+  s.defer = true;
+  document.head.appendChild(s);
+})();

--- a/ja/developer-resources/sdks/rust.mdx
+++ b/ja/developer-resources/sdks/rust.mdx
@@ -106,10 +106,10 @@ async fn main() -> dodopayments::Result<()> {
 
 | Name        | Base URL                          |
 | ----------- | --------------------------------- |
-| デフォルト   | https://api.example.com          |
-| ステージング | https://staging.example.com      |
+| `live_mode` | `https://live.dodopayments.com`   |
+| `test_mode` | `https://test.dodopayments.com`   |
 
-デフォルトのベースURLはhttps://api.example.comです。URLをハードコーディングせずに別の環境を選択してください：
+デフォルトのベースURLは`https://live.dodopayments.com`です。URLをハードコーディングせずに別の環境を選択してください：
 
 ```rust
 use dodopayments::{Client, ClientConfig, Environment};


### PR DESCRIPTION
Adds the root-level loader that mounts the **"Ask AI"** (Sentra) chat assistant on docs.dodopayments.com.

## What this does
- Adds `assistant-loader.js` at the repo root. Mintlify **auto-injects every root-level `.js`** on every page (the same mechanism that loads `seo.js`), so **no `docs.json` change is needed**.
- The loader injects the widget bundle served from the private Cloudflare Worker (`https://chat.dodopayments.com/widget.js`) and sets the `window.DodoAssistant` config.

## What it does NOT add
- No heavy JS or bundle in this repo (the widget lives in the `dodo-chat-assistant` Worker).
- **No secrets.** Only the public chat endpoint and the **public** Turnstile sitekey ship to the browser; the matching secret key never leaves the Worker.

## How it works
- `chatEndpoint: https://chat.dodopayments.com/chat`, public Turnstile sitekey, 4 starter questions, `Cmd/Ctrl-I` hotkey.
- Idempotent across Mintlify SPA navigations (guards against double-injection; the widget also guards duplicate hosts).

## Go-live dependency
The widget bundle + backend are served by the `dodo-chat-assistant` Worker (`chat.dodopayments.com`). For the latest widget UX and answer-quality improvements to appear, that Worker must be deployed with the current bundle. This PR only wires the loader into the docs site.

## Test plan
- `mintlify dev` → open `http://localhost:3000/introduction`: the "Ask AI" launcher appears; sending a question streams a grounded answer with citations (against the deployed `chat.dodopayments.com/chat`).
- Client-navigate to `/features/subscription` and confirm exactly one `#dodo-assistant-host` mounts; `seo.js` JSON-LD still present.