### PR TITLE
docs: clarify billing cycle reset behavior for seat proration modes

### DIFF
--- a/features/seat-based-billing.mdx
+++ b/features/seat-based-billing.mdx
@@ -322,11 +322,16 @@ sequenceDiagram
 
 ### Proration Modes
 
-| Mode | Adding Seats | Removing Seats |
-|------|-------------|----------------|
-| `prorated_immediately` | Charge for remaining days in cycle | Credit for unused days |
-| `difference_immediately` | Charge full seat price | Credit applied to future renewals |
-| `full_immediately` | Charge full seat price, reset billing cycle | No credit |
+| Mode | Adding Seats | Removing Seats | Billing cycle |
+|------|-------------|----------------|---------------|
+| `prorated_immediately` | Charge for remaining days in cycle | Credit for unused days | Resets to today |
+| `difference_immediately` | Charge full seat price | Credit applied to future renewals | Resets to today |
+| `full_immediately` | Charge full seat price | No credit | Resets to today |
+| `do_not_bill` | Seat added, no charge now | Seat removed, no credit | Stays the same |
+
+<Warning>
+`prorated_immediately`, `difference_immediately`, and `full_immediately` all **reset the billing cycle to the change date** — the next renewal is re-anchored to the day the seat change is applied. Only **`do_not_bill`** keeps the original renewal date (the new seat count is billed in full at the next renewal, with no charge at the time of change).
+</Warning>
 
 ### Proration Examples
 
@@ -338,15 +343,17 @@ sequenceDiagram
 Prorated charge = ($10 × 5 seats) × (15 days / 30 days)
                 = $50 × 0.5
                 = $25 immediate charge
+Billing cycle resets to today
 ```
-Customer pays $25 now, then $50/month on renewal.
+Customer pays the prorated amount now, and the billing cycle re-anchors to the change date — the next renewal ($50/month for the added seats) is charged one cycle from today, not from the original renewal date.
 </Tab>
 
 <Tab title="difference_immediately">
 ```
 Immediate charge = $10 × 5 seats = $50
+Billing cycle resets to today
 ```
-Customer pays full $50 now, regardless of cycle position.
+Customer pays the full seat price now, regardless of cycle position, and the billing cycle re-anchors to the change date.
 </Tab>
 
 <Tab title="full_immediately">
@@ -355,6 +362,14 @@ Immediate charge = Full subscription + add-ons
 Billing cycle resets to today
 ```
 Customer pays full amount, new billing cycle starts.
+</Tab>
+
+<Tab title="do_not_bill">
+```
+Immediate charge = $0
+Billing cycle unchanged
+```
+Seats are added immediately with no charge at the time of change. The original renewal date is preserved, and the new seat count is billed in full at the next renewal. Use this when you need to keep the existing billing cycle.
 </Tab>
 </Tabs>
 
@@ -376,7 +391,7 @@ Credit for removed seats:
 ```
 
 <Tip>
-**Choosing a proration mode for seat changes**: Use `prorated_immediately` for fair day-based billing when teams frequently adjust seats. Use `difference_immediately` for simpler math that charges or credits the full seat price. See the [Proration Guide](/developer-resources/subscription-upgrade-downgrade#proration-modes) for detailed comparisons.
+**Choosing a proration mode for seat changes**: Use `prorated_immediately` for fair day-based billing when teams frequently adjust seats. Use `difference_immediately` for simpler math that charges or credits the full seat price. If you need to keep the existing renewal date unchanged, use `do_not_bill` — the only mode that does not reset the billing cycle (the new seat count is billed at the next renewal). See the [Proration Guide](/developer-resources/subscription-upgrade-downgrade#proration-modes) for detailed comparisons.
 </Tip>
 
 ### Preview Before Changing


### PR DESCRIPTION
## Summary

Clarifies how seat-based billing proration modes affect the subscription billing cycle, addressing confusion about which modes re-anchor the renewal date.

- Documents that `prorated_immediately`, `difference_immediately`, and `full_immediately` all **reset the billing cycle to the change date** (the next renewal re-anchors to the day the seat change is applied).
- Adds the **`do_not_bill`** mode — the only mode that preserves the original renewal date (new seat count billed in full at the next renewal, no charge at change time).
- Updates the proration modes table, adds a `<Warning>` callout, a `do_not_bill` proration example tab, and expands the proration-mode selection tip.

## Changes

- `features/seat-based-billing.mdx`