### PR TITLE
feat: drive Sentra "Ask AI" assistant via ContextChat config

### DIFF
--- a/assistant-loader.js
+++ b/assistant-loader.js
@@ -1,21 +1,30 @@
-// Dodo Payments docs — "Ask AI" assistant loader.
+// Dodo Payments docs — "Ask AI" (Sentra) assistant loader.
 //
 // Mintlify auto-injects every root-level `.js` file on every page (same mechanism that
-// loads `seo.js`). This file injects the self-owned chat widget bundle and its config.
-// The widget bundle itself is served from the private Cloudflare Worker, NOT this repo,
-// so no heavy JS or secrets live here — only the public endpoint + Turnstile sitekey.
+// loads `seo.js`). This injects the ContextChat widget bundle and its config. The bundle
+// is served from the Cloudflare Worker (ContextChat), NOT this repo — so no heavy JS or
+// secrets live here, only the public endpoint, Turnstile sitekey, brand copy, and theme.
+//
+// The widget bundle is generic/de-branded (open-sourced as ContextChat); Sentra's entire
+// identity — name, copy, brand palette (light + dark), and fonts — is reproduced from the
+// config below.
 (function () {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   var WIDGET_SRC = "https://chat.dodopayments.com/widget.js";
   var SCRIPT_ID = "dodo-assistant-widget-script";
 
-  // Config consumed by widget.js (the `window.DodoAssistant` contract).
-  // turnstileSitekey is a PUBLIC key (safe to ship to the browser); the matching
-  // secret key never leaves the Worker.
-  window.DodoAssistant = {
+  var config = {
     chatEndpoint: "https://chat.dodopayments.com/chat",
+    // PUBLIC Turnstile sitekey (safe to ship); the matching secret never leaves the Worker.
     turnstileSitekey: "0x4AAAAAADrfVZLFta7tMqJJ",
+
+    assistantName: "Sentra",
+    tagline: "Answers from the Dodo Payments docs",
+    welcomeHeading: "Ask Sentra about Dodo Payments",
+    welcomeSubtext: "Get answers from the documentation, with sources.",
+    launcherLabel: "Ask AI",
+    disclaimer: "AI can make mistakes. Verify important details in the docs.",
     starterQuestions: [
       "How do I create a subscription?",
       "How do I integrate Checkout?",
@@ -23,10 +32,78 @@
       "How do webhooks work?",
     ],
     hotkey: "mod+i",
+
+    // Body = Inter, headings/display = ApfelGrotezk. Both are already registered as
+    // document-level @font-face by Mintlify (docs.json `fonts`), and @font-face is
+    // global to the document, so the widget's Shadow DOM can use them by name.
+    fontFamily: "Inter, ui-sans-serif, system-ui, -apple-system, sans-serif",
+    fontFamilyDisplay: "ApfelGrotezk, Inter, ui-sans-serif, system-ui, sans-serif",
+
+    // Dodo brand palette — light.
+    theme: {
+      "--background": "#ffffff",
+      "--foreground": "#292a25",
+      "--card": "#ffffff",
+      "--card-foreground": "#292a25",
+      "--popover": "#ffffff",
+      "--popover-foreground": "#292a25",
+      "--primary": "#779812",
+      "--primary-foreground": "#ffffff",
+      "--primary-hover": "#166534",
+      "--secondary": "#f1f3ea",
+      "--secondary-foreground": "#2c3413",
+      "--muted": "#f5f6f1",
+      "--muted-foreground": "#53554f",
+      "--accent": "#eef3df",
+      "--accent-foreground": "#2c3413",
+      "--destructive": "#b42318",
+      "--destructive-foreground": "#ffffff",
+      "--border": "#e5e7e0",
+      "--input": "#e5e7e0",
+      "--ring": "#779812",
+      "--radius": "0.75rem",
+      "--ring-soft": "rgba(119, 152, 18, 0.18)",
+      "--shadow-launcher": "0 1px 2px rgba(20, 24, 10, 0.12), 0 10px 28px -10px rgba(119, 152, 18, 0.5)",
+      "--shadow-launcher-hover": "0 2px 6px rgba(20, 24, 10, 0.16), 0 18px 38px -10px rgba(119, 152, 18, 0.62)",
+      "--shadow-panel": "0 1px 2px rgba(20, 24, 10, 0.08), 0 24px 50px -16px rgba(20, 24, 10, 0.26), 0 8px 18px -12px rgba(20, 24, 10, 0.18)",
+    },
+
+    // Dodo brand palette — dark.
+    themeDark: {
+      "--background": "#191a17",
+      "--foreground": "#ffffff",
+      "--card": "#1f201c",
+      "--card-foreground": "#ffffff",
+      "--popover": "#1f201c",
+      "--popover-foreground": "#ffffff",
+      "--primary": "#c6fe1e",
+      "--primary-foreground": "#14180a",
+      "--primary-hover": "#d4ff4d",
+      "--secondary": "#262620",
+      "--secondary-foreground": "#eaf3d3",
+      "--muted": "#232420",
+      "--muted-foreground": "#a2a49e",
+      "--accent": "#2b3315",
+      "--accent-foreground": "#eaf3d3",
+      "--destructive": "#ff9b8f",
+      "--destructive-foreground": "#14180a",
+      "--border": "#2c2d28",
+      "--input": "#34352f",
+      "--ring": "#c6fe1e",
+      "--ring-soft": "rgba(198, 254, 30, 0.16)",
+      "--shadow-launcher": "0 1px 2px rgba(0, 0, 0, 0.5), 0 10px 28px -10px rgba(198, 254, 30, 0.3)",
+      "--shadow-launcher-hover": "0 2px 6px rgba(0, 0, 0, 0.6), 0 18px 38px -10px rgba(198, 254, 30, 0.42)",
+      "--shadow-panel": "0 1px 2px rgba(0, 0, 0, 0.6), 0 24px 56px -16px rgba(0, 0, 0, 0.72), 0 8px 20px -12px rgba(0, 0, 0, 0.55)",
+    },
   };
 
-  // Idempotent across Mintlify SPA navigations: if the loader runs again, don't
-  // re-inject the bundle. (The widget also guards against duplicate hosts.)
+  // Set the new global and mirror to the legacy one so the currently-deployed widget keeps
+  // working during cutover: the old bundle reads only chatEndpoint/turnstile/starters/hotkey
+  // from window.DodoAssistant and ignores the extra fields; the new bundle reads window.ContextChat.
+  window.ContextChat = config;
+  window.DodoAssistant = config;
+
+  // Idempotent across Mintlify SPA navigations.
   if (document.getElementById(SCRIPT_ID)) return;
 
   var s = document.createElement("script");


### PR DESCRIPTION
## What

Updates the docs "Ask AI" (Sentra) loader to drive the chat widget via the
`window.ContextChat` config contract, supplying Sentra's **full identity from
config**: name, copy, brand palette (light **and** dark), fonts, and starter
questions.

## Why

The chat widget bundle (served from `chat.dodopayments.com`) is being
open-sourced as a generic, de-branded project (**ContextChat**). The bundle no
longer hard-codes any Dodo branding — so the host page must now supply it. This
loader reproduces today's Sentra exactly, with zero Dodo specifics living in the
widget bundle.

## Zero-regression cutover

This PR is **safe to merge before** the new widget bundle deploys. The config is
mirrored to the legacy `window.DodoAssistant` global:

- **Currently-deployed widget** reads only `chatEndpoint` / `turnstileSitekey` /
  `starterQuestions` / `hotkey` from `window.DodoAssistant` and ignores the new
  fields → Sentra renders unchanged.
- **New ContextChat widget** (deployed separately, follow-up step) reads
  `window.ContextChat` → full Sentra branding, now config-driven.

So the safe order is: **merge this loader first**, then deploy the new widget
bundle to `chat.dodopayments.com`.

## Details

- Brand palette supplied as `theme` (light) + `themeDark` (dark), matching the
  current green light/dark tokens exactly.
- Fonts: `fontFamily: Inter`, `fontFamilyDisplay: ApfelGrotezk`. Both are already
  registered as document-level `@font-face` by Mintlify (`docs.json` `fonts`), and
  `@font-face` is global to the document, so the widget's Shadow DOM resolves them
  by name (no extra font stylesheet needed).
- All visible strings, starter questions, hotkey, and the public Turnstile
  sitekey are unchanged from the current loader.

## Verification

- `node --check` passes on the loader.
- The widget config path (light/dark palette swap + independent display font) was
  browser-verified in the ContextChat repo before preparing this loader.
- Follow-up (separate): deploy the new widget bundle, then live-QA Sentra parity
  on `docs.dodopayments.com` (esp. confirm ApfelGrotezk renders in the Shadow DOM).
