### PR TITLE
docs(changelog): add v1.106.0 release notes

### DIFF
--- a/changelog/introduction.mdx
+++ b/changelog/introduction.mdx
@@ -10,6 +10,7 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates"]
 
 | Version | Release Date | Highlights |
 |---------|--------------|------------|
+| [v1.106.0](/changelog/v1.106.0) | July 7, 2026 | Localized Pricing with per-currency and per-country price rules, three new payment methods (Satispay, BLIK, and Klarna for subscriptions), feature flag entitlements, Apple Pay domain registration, editable add-ons at checkout, subscription period extension, and add-on image removal |
 | [v1.105.0](/changelog/v1.105.0) | June 22, 2026 | Bring Your Own Processor (BYOP), official Rust SDK release, Korean wallets and Przelewy24 payment methods, `brand_id` on every webhook payload, decimal-aware currency handling, higher entitlement limits, branded recovery emails, analytics v2.1, and dashboard polish |
 | [v1.101.0](/changelog/v1.101.0) | June 2, 2026 | Automatic subscription payment retries to recover failed renewal revenue, business-level proration defaults with per-product-collection overrides, and business name collection for B2B invoices |
 | [v1.99.0](/changelog/v1.99.0) | May 25, 2026 | Stacked discount codes (up to 20 per checkout, payment, or subscription), seven new customer notification emails for refunds and subscription lifecycle events, Sunbit BNPL for US customers, checkout payment page overhaul lifting success rates by 2–3%, product form rework with live preview and autosave, and Business Settings redesign |

--- a/changelog/v1.106.0.mdx
+++ b/changelog/v1.106.0.mdx
@@ -1,0 +1,105 @@
+---
+title: v1.106.0 (July 7, 2026)
+description: "Localized Pricing with per-currency and per-country price rules, three new payment methods (Satispay, BLIK, and Klarna for subscriptions), feature flag entitlements, Apple Pay domain registration, and editable add-ons at checkout — plus subscription period extension and add-on image removal."
+icon: "arrows-turn-right"
+keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1.106.0 (july 7, 2026)", "localized pricing", "payment methods", "feature flags", "apple pay", "satispay", "blik", "klarna"]
+---
+
+## New Features
+
+### 1. **Localized Pricing**
+
+You can now set **fixed prices per currency or per country** instead of letting exchange rates decide the amount a customer sees. Turn it on by setting a `pricing_mode` on a product, then attach one price rule per market:
+
+| Mode | What it does | Example |
+|------|--------------|---------|
+| `by_currency` | One fixed price per currency, regardless of country | Everyone paying in EUR sees **€9.99** |
+| `by_country` | A price specific to a country, even when several countries share a currency | **₹999 in India** on a $20 base product |
+
+Manage rules through the new `/products/{product_id}/localized-prices` endpoints (create, list, get, patch, archive). Each rule's `amount` is an integer in the currency's smallest unit — a price you set, never a converted value.
+
+When no rule matches, the product keeps its existing behavior: customers in your base currency pay the base price directly, and everyone else is converted through Adaptive Currency. When a rule **does** match, the customer pays **exactly** the amount you set — the Adaptive Currency FX fee is absorbed rather than added on top.
+
+This is the recommended, native way to run **Purchasing Power Parity (PPP)**, charm pricing (€9.99, ¥1000, ₹499), reversible market-entry promotions, and competitive price-matching.
+
+Learn more: [Localized Pricing](/features/localized-pricing) | [Adaptive Currency](/features/adaptive-currency) | [Purchasing Power Parity](/features/purchasing-power-parity)
+
+### 2. **New Payment Methods: Satispay, BLIK & Klarna for Subscriptions**
+
+Three additions expand local coverage in Europe and bring Buy Now, Pay Later to recurring billing.
+
+| Method | API type | Region | Currency | Subscriptions |
+|--------|----------|--------|----------|---------------|
+| **Satispay** | `satispay` | Europe (Italy) | EUR | Yes |
+| **BLIK** | `blik` | Poland | PLN | No (one-time only) |
+| **Klarna** | `klarna` | United States | USD | **Yes (new)** |
+
+- **Satispay** surfaces on EUR checkouts for both one-time and subscription payments within the supported amount range.
+- **BLIK**, Poland's most popular online payment method (~60% market share), settles in `PLN` and supports one-time payments.
+- **Klarna** can now be used for **subscriptions** on USD checkouts with US billing above the $50 minimum — previously it was limited to one-time payments.
+
+Learn more: [European Payment Methods](/features/payment-methods/europe) | [Buy Now, Pay Later](/features/payment-methods/bnpl) | [Payment Methods Overview](/features/payment-methods)
+
+### 3. **Feature Flag Entitlements**
+
+A new **feature flag** entitlement type turns Dodo Payments into a billing-aware feature-flag store. Attach a flag like `advanced_reports` to a product, and every paying customer instantly gets a grant your application can check — no external platform, no OAuth, and no delivery step that can fail.
+
+- On purchase, the grant is created and moves straight to `delivered`. There is no `pending` phase and no customer action.
+- The grant carries a typed `feature` payload — `{ "feature_type": "boolean", "feature_id": "advanced_reports" }` — and your application reads `feature_id` to decide what to unlock.
+- Cancellation, refund, or manual revoke moves the grant to `revoked`, and the flag disappears automatically.
+
+You can read a customer's grants with the new **`GET /customers/{customer_id}/entitlement-grants`** endpoint (status and integration-type filters, paginated), or keep them in sync via webhooks. Entitlement metadata now also supports a `string | number | boolean` scalar union, so you can attach limits and quotas alongside the flag.
+
+Learn more: [Feature Flag Entitlement](/features/entitlements/feature-flags) | [Entitlements](/features/entitlements/introduction)
+
+### 4. **Apple Pay Domain Registration**
+
+You can now register and verify **your own domains** for Apple Pay directly from the dashboard, enabling one-tap Apple Pay on inline (embedded) checkout hosted on your site.
+
+Set it up from **Settings → Payment Methods**: on the **Apple Pay** row, click **Manage domains**, download the domain-association file, host it on your domain, then register and verify. Domain verification is only required for inline (embedded) checkout — overlay checkout, hosted checkout, and payment links work without it.
+
+<Info>
+Disabling a domain is a kill switch that stops Dodo from offering Apple Pay on that domain at checkout — it does not unregister the domain with Apple.
+</Info>
+
+Learn more: [Digital Wallets](/features/payment-methods/digital-wallets)
+
+### 5. **Editable Add-ons at Checkout**
+
+A new `allow_editing_addons` feature flag on checkout sessions lets customers **add or remove add-ons on a subscription product during checkout**, instead of locking the cart to a fixed set of add-ons.
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'prod_abc', quantity: 1 }],
+  feature_flags: {
+    allow_editing_addons: true // customers can edit add-ons at checkout
+  },
+  return_url: 'https://yoursite.com/return'
+});
+```
+
+The flag defaults to `false` and only applies to subscription products. It is also surfaced on `GET /checkout/sessions/{id}` so your front end knows whether add-on editing is enabled for a session.
+
+Learn more: [Checkout Session](/developer-resources/checkout-session) | [Add-ons](/features/addons)
+
+## Improvements & Bug Fixes
+
+### 6. **Extend a Subscription's Period via `PATCH /subscriptions`**
+
+`PATCH /subscriptions/{id}` now accepts `subscription_period_count` and `subscription_period_interval`, so you can **extend** a subscription's current period — for example, to grant extra time. The subscription's expiry (`expires_at`) is recomputed from the new count and interval and persisted.
+
+<Note>
+A subscription's period can only be **increased**, never shortened.
+</Note>
+
+Learn more: [Update Subscription](/api-reference/subscriptions/patch-subscriptions)
+
+### 7. **Remove Images From Add-ons**
+
+`PATCH /addons/{id}` now supports clearing an add-on's image by sending `image_id: null`. An explicit `null` removes the image, while omitting the field leaves it unchanged — matching the same convention used by products and product collections.
+
+Learn more: [Update Add-on](/api-reference/addons/update-addon)
+
+### Other Fixes & Improvements
+
+- Minor bug fixes and stability improvements across the platform.

--- a/changelog/v1.106.0.mdx
+++ b/changelog/v1.106.0.mdx
@@ -11,6 +11,10 @@ keywords: ["Dodo Payments", "changelog", "release notes", "product updates", "v1
 
 You can now set **fixed prices per currency or per country** instead of letting exchange rates decide the amount a customer sees. Turn it on by setting a `pricing_mode` on a product, then attach one price rule per market:
 
+<Frame>
+<img src="/images/localized-pricing/pricing-section.png" alt="Localized Pricing enabled on the product form with By Country selected" style={{ maxHeight: '450px', width: 'auto' }} />
+</Frame>
+
 | Mode | What it does | Example |
 |------|--------------|---------|
 | `by_currency` | One fixed price per currency, regardless of country | Everyone paying in EUR sees **€9.99** |
@@ -44,6 +48,10 @@ Learn more: [European Payment Methods](/features/payment-methods/europe) | [Buy 
 
 A new **feature flag** entitlement type turns Dodo Payments into a billing-aware feature-flag store. Attach a flag like `advanced_reports` to a product, and every paying customer instantly gets a grant your application can check — no external platform, no OAuth, and no delivery step that can fail.
 
+<Frame>
+<img src="/images/entitlements/feature-flags/create.png" alt="New Feature Flag form with display name, feature ID, description, and metadata key-value entries" style={{ maxHeight: '500px', width: 'auto' }} />
+</Frame>
+
 - On purchase, the grant is created and moves straight to `delivered`. There is no `pending` phase and no customer action.
 - The grant carries a typed `feature` payload — `{ "feature_type": "boolean", "feature_id": "advanced_reports" }` — and your application reads `feature_id` to decide what to unlock.
 - Cancellation, refund, or manual revoke moves the grant to `revoked`, and the flag disappears automatically.
@@ -57,6 +65,10 @@ Learn more: [Feature Flag Entitlement](/features/entitlements/feature-flags) | [
 You can now register and verify **your own domains** for Apple Pay directly from the dashboard, enabling one-tap Apple Pay on inline (embedded) checkout hosted on your site.
 
 Set it up from **Settings → Payment Methods**: on the **Apple Pay** row, click **Manage domains**, download the domain-association file, host it on your domain, then register and verify. Domain verification is only required for inline (embedded) checkout — overlay checkout, hosted checkout, and payment links work without it.
+
+<Frame caption="Register the domain where you embed checkout">
+<img src="/images/apple-pay-domains/register-domain.png" alt="Register a domain form with a domain entered" style={{ maxHeight: '500px', width: 'auto' }} />
+</Frame>
 
 <Info>
 Disabling a domain is a kill switch that stops Dodo from offering Apple Pay on that domain at checkout — it does not unregister the domain with Apple.

--- a/docs.json
+++ b/docs.json
@@ -714,6 +714,12 @@
                 ]
               },
               {
+                "group": "July 2026",
+                "pages": [
+                  "changelog/v1.106.0"
+                ]
+              },
+              {
                 "group": "June 2026",
                 "pages": [
                   "changelog/v1.105.0",

--- a/features/addons.mdx
+++ b/features/addons.mdx
@@ -167,6 +167,19 @@ const session = await client.checkoutSessions.create({
 });
 ```
 
+<Tip>
+To let customers add or remove add-ons themselves on the checkout page, set the [`allow_editing_addons`](/developer-resources/checkout-session#optional-fields) feature flag to `true` when creating the session. It defaults to `false` and applies only to subscription products.
+
+```typescript
+const session = await client.checkoutSessions.create({
+  product_cart: [{ product_id: 'your_subscription_id', quantity: 1 }],
+  feature_flags: {
+    allow_editing_addons: true // customers can edit add-ons at checkout
+  },
+});
+```
+</Tip>
+
 ### Plan Changes with Add-ons
 Modify existing subscriptions to add, remove, or update add-ons:
 

--- a/features/products.mdx
+++ b/features/products.mdx
@@ -54,6 +54,10 @@ Then set pricing:
 - **Discount (%)**: Optional inline discount shown in checkout and invoices.
 - For subscriptions, set **Repeat every** (e.g., 1 month or 1 year) and **Trial days** if needed. The subscription price must be at least **$1** (or the equivalent in your chosen currency); amounts below this minimum are not supported and the subscription will not work.
 
+<Tip>
+Want a fixed price per currency or country instead of a live FX conversion? Set a `pricing_mode` on the product and attach [Localized Pricing](/features/localized-pricing) rules — for example €9.99 in EUR or ₹999 in India.
+</Tip>
+
 <Warning>
 Changing price affects only new purchases. Existing subscriptions follow plan‑change rules.
 </Warning>
@@ -211,8 +215,13 @@ You're ready to create products and start selling - one‑time, recurring, or by
 
 ## Related
 
+<CardGroup cols={2}>
 <Card title="Product Analytics" icon="chart-mixed" href="/features/analytics-and-reporting#product-level-analytics">
 Track revenue, customers, retention, subscribers, and MRR for each individual product.
 </Card>
+<Card title="Localized Pricing" icon="earth-americas" href="/features/localized-pricing">
+Set fixed per-currency or per-country prices on a product instead of relying on live exchange rates.
+</Card>
+</CardGroup>
 
 

--- a/features/subscription.mdx
+++ b/features/subscription.mdx
@@ -549,6 +549,20 @@ await client.subscriptions.update('sub_123', {
 });
 ```
 
+### Extend the subscription period
+Extend how long a subscription runs by passing a new `subscription_period_count` and `subscription_period_interval` to `PATCH /subscriptions/{id}`. The subscription's expiry is recomputed from the new count and interval — for example, to grant a customer extra time on their current plan:
+
+```typescript
+await client.subscriptions.update('sub_123', {
+  subscription_period_count: 5,
+  subscription_period_interval: 'Month'
+});
+```
+
+<Note>
+A subscription's period can only be **increased**, never shortened.
+</Note>
+
 ### On‑demand subscriptions
 Create an on‑demand subscription and charge later as needed:
 


### PR DESCRIPTION
## Summary

Adds the **v1.106.0 (July 7, 2026)** changelog entry, registers it under a new **July 2026** group in `docs.json`, adds it to the changelog introduction **Version Logs** table, and cross-references the new features from related feature pages. Features are ordered by importance, with dashboard screenshots on the top sections.

### New Features (in priority order)
1. **Localized Pricing** — fixed per-currency (`by_currency`) / per-country (`by_country`) price rules via `pricing_mode` and the new `/products/{product_id}/localized-prices` endpoints. _(with screenshot)_
2. **New Payment Methods** — **Satispay** (EUR, subscriptions), **BLIK** (PLN, one-time), and **Klarna now supported for subscriptions** (USD, US billing above $50).
3. **Feature Flag Entitlements** — new in-house `feature_flag` entitlement type delivering a boolean capability instantly on payment, plus `GET /customers/{customer_id}/entitlement-grants`. _(with screenshot)_
4. **Apple Pay Domain Registration** — register/verify your own domains for Apple Pay on inline checkout from the dashboard. _(with screenshot)_
5. **Editable Add-ons at Checkout** — new `allow_editing_addons` checkout-session feature flag (default `false`, subscription products).

### Improvements & Bug Fixes
- **Extend a subscription's period via `PATCH /subscriptions`** — `subscription_period_count` / `subscription_period_interval` (increase only).
- **Remove images from add-ons** — `PATCH /addons/{id}` with `image_id: null` clears the image.

## Files changed
- `changelog/v1.106.0.mdx` — new release notes (with 3 screenshots).
- `changelog/introduction.mdx` — new row at the top of the Version Logs table.
- `docs.json` — entry registered under a new July 2026 group in the English nav.
- `features/products.mdx` — link Localized Pricing from the pricing step and Related cards.
- `features/addons.mdx` — document the `allow_editing_addons` checkout feature flag.
- `features/subscription.mdx` — add an "Extend the subscription period" PATCH example.

## Cross-reference audit
Verified with the repo's own `scripts/findMissingPages.ts` that every v1.106.0 feature is already fully covered by feature pages, API-reference stubs, and the OpenAPI spec (all registered in `docs.json`). The three feature-page edits above close the remaining discoverability gaps.

## Verification
Every feature was cross-checked against `../backend` (PRs #1568, #1560, #1552, #1545, payment-method routing in `payments.rs`, `localized_prices.rs`, `payment_method_domains.rs`) and `../frontend` (i18n localized-pricing, Satispay/BLIK/Klarna, Apple Pay domain, entitlement, add-on editing work).

- `docs.json` validates as JSON; entry registered in the English `language: "en"` nav.
- All internal links and anchors resolve; all 3 referenced images exist on disk (reused from the verified feature pages).
- `subscription_period_interval` example uses the correct `TimeInterval` enum casing (`Month`).
- Translated locale nav is intentionally left to the automated `Sync Languages` workflow.