### PR TITLE
docs(localized-pricing): document localized pricing on subscription plan changes

### DIFF
--- a/features/localized-pricing.mdx
+++ b/features/localized-pricing.mdx
@@ -302,6 +302,34 @@ Each cart line is resolved on its own, so you can localize one product and leave
 
 ---
 
+## How It Applies on Subscription Plan Changes
+
+When an existing subscriber switches to a different plan, the new plan's localized price is resolved the same way it is at checkout — so an upgrade or downgrade honors your fixed local prices instead of reverting to a live FX conversion of the base price.
+
+The subscription is already locked to a country and a currency from when it was created, and the resolver reuses both:
+
+- **Billing country** — the country locked on the subscription drives `by_country` rule matching.
+- **Presentment currency** — the currency the subscriber is billed in (their adaptive currency when one is set, otherwise the subscription currency) drives `by_currency` rule matching.
+
+When the new plan has a matching rule:
+
+- A **`by_currency`** rule keyed on the subscriber's presentment currency charges the exact amount you set.
+- A **`by_country`** rule in a different currency is FX-converted to the subscription's billing currency — it is applied, not skipped.
+- The change is forced **fees-inclusive**, so the customer pays exactly the localized price, and that setting governs the new plan's renewals going forward.
+- For a proration-based upgrade, the credit for the old plan comes from its previously charged amount, while the new plan is billed at its localized price.
+
+When no rule matches (or the new plan has no `pricing_mode`), the base price applies and is converted through [Adaptive Currency](/features/adaptive-currency), exactly as before.
+
+<Info>
+This resolution is shared across every path that changes a plan: merchant-initiated changes and their previews, the Customer Portal, scheduled plan changes (the amount is fixed when the change is scheduled), and renewal carry-forward. A preview always reflects the same amount that will be charged when the change is applied.
+</Info>
+
+<Note>
+The subscription's billing currency is never switched by a plan change, and localized pricing on plan changes does not apply to add-ons or metered per-unit prices.
+</Note>
+
+---
+
 ## Important Behaviors
 
 | Behavior | Detail |
@@ -311,6 +339,8 @@ Each cart line is resolved on its own, so you can localize one product and leave
 | **By-currency differs from base** | A `by_currency` rule must use a currency different from the product's base currency. |
 | **One rule per market** | A product can have at most one active rule per currency (by-currency) or per country (by-country). |
 | **All product types** | Applies to one-time, subscription, and usage-based products. |
+| **Applies on plan changes** | When a subscriber changes plans, the new plan's localized price is resolved from the subscription's locked country and presentment currency — see [How It Applies on Subscription Plan Changes](#how-it-applies-on-subscription-plan-changes). |
+| **Not add-ons on plan changes** | On a plan change, localized pricing resolves the plan price only; add-ons and metered per-unit prices are unaffected. |
 
 <Info>
 Localized rule changes do not emit their own webhooks. The resolved amount appears on the resulting payment or subscription exactly like any other price.


### PR DESCRIPTION
## What

Documents the new backend behavior from [dodopayments/backend#1681](https://github.com/dodopayments/backend/pull/1681): a product's localized price is now applied when an existing subscriber **changes into that plan**, matching how localized pricing is already honored at checkout and subscription creation.

## Changes to `features/localized-pricing.mdx`

- **New section "How It Applies on Subscription Plan Changes"** covering:
  - The resolver reuses the subscription's locked **billing country** (`by_country` matching) and **presentment currency** — the adaptive currency when set, otherwise the subscription currency (`by_currency` matching).
  - `by_currency` rule keyed on the presentment currency charges the exact amount; a `by_country` rule in a different currency is FX-converted (applied, not skipped).
  - The change is forced **fees-inclusive**, and that setting governs the new plan's renewals.
  - Proration upgrades credit the old plan from its charged amount while billing the new plan at its localized price.
  - Shared across merchant apply/preview, the Customer Portal, scheduled changes, and renewal carry-forward; preview matches the applied amount.
  - Out of scope: switching the subscription billing currency, add-ons, and metered per-unit prices.
- **"Important Behaviors" table**: added rows noting plan-change coverage and the add-on/metered exclusion.

## Notes

- Change is contained within an existing page, so `docs.json` needs no update.
- English source only; translated language folders are regenerated separately via the i18n tooling per repo conventions.
- MDX component tags verified balanced; internal anchor/links resolve to existing headings and pages.

---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/80e48944cd59e639f89989fcc55f24b5)*