### PR TITLE
docs(localized-pricing): document localized pricing on subscription plan changes

### DIFF
--- a/features/localized-pricing.mdx
+++ b/features/localized-pricing.mdx
@@ -302,6 +302,25 @@ Each cart line is resolved on its own, so you can localize one product and leave
 
 ---
 
+## How It Applies on Subscription Plan Changes
+
+Localized pricing follows your subscribers when they switch plans. When an existing subscription [changes plan](/features/subscription#subscription-plan-changes) into a product that has a `pricing_mode`, the new plan's price is resolved with the same rules as checkout, using the billing country and currency already locked on the subscription:
+
+- **By Country**: a rule matching the subscription's billing country applies. If the rule's currency differs from the currency the subscription is billed in, the rule's amount is converted at live FX rates — the rule is applied, not skipped.
+- **By Currency**: a rule matching the currency the customer is billed in applies, and the customer is charged exactly the rule's amount.
+- **No match, or no `pricing_mode`**: the new plan's base price applies, converted through [Adaptive Currency](/features/adaptive-currency) when needed — the same fallback as checkout.
+
+This holds everywhere a plan change can originate: the [Change Plan API](/api-reference/subscriptions/change-plan), the [Customer Portal](/features/customer-portal)'s self-service plan changes, and changes scheduled for the end of the billing period.
+
+- **Previews are exact.** [Preview Change Plan](/api-reference/subscriptions/preview-change-plan) returns the same localized amount the actual change charges.
+- **Renewals keep the localized price.** After the change, the new plan renews at its localized amount — and stays fees-inclusive — exactly like a subscription created at that price.
+- **Proration uses real amounts.** On an upgrade, the credit for unused time is based on what the customer actually paid for the old plan, while the new plan is priced by its localized rule.
+- **Scheduled changes lock the price when scheduled.** A change scheduled for the end of the billing period charges the amount calculated at scheduling time, even if you edit the rule in between.
+- **The billing currency never changes.** A plan change never switches the currency a subscription settles in; a rule in another currency is FX-converted into it.
+- **Add-ons are not localized.** Add-on prices on the new plan always use their base pricing.
+
+---
+
 ## Important Behaviors
 
 | Behavior | Detail |
@@ -310,7 +329,7 @@ Each cart line is resolved on its own, so you can localize one product and leave
 | **Not for Pay What You Want** | Localized rules never apply to [Pay What You Want](/features/pay-what-you-want) products, where the customer chooses the amount. |
 | **By-currency differs from base** | A `by_currency` rule must use a currency different from the product's base currency. |
 | **One rule per market** | A product can have at most one active rule per currency (by-currency) or per country (by-country). |
-| **All product types** | Applies to one-time, subscription, and usage-based products. |
+| **All product types** | Applies to one-time, subscription, and usage-based products — including when an existing subscriber [changes plan](#how-it-applies-on-subscription-plan-changes). |
 
 <Info>
 Localized rule changes do not emit their own webhooks. The resolved amount appears on the resulting payment or subscription exactly like any other price.


### PR DESCRIPTION
## Summary

Backend PR dodopayments/backend#1681 (merged) extends localized pricing to subscription plan changes: when an existing subscriber changes into a product with a `pricing_mode`, the new plan's localized price is resolved the same way it is at checkout, using the subscription's locked billing country and billing currency.

This PR updates the [Localized Pricing](https://docs.dodopayments.com/features/localized-pricing) feature page to match:

- New **How It Applies on Subscription Plan Changes** section covering:
  - Rule resolution against the subscription's locked billing country/currency
  - Cross-currency `by_country` rules are FX-converted, not skipped
  - Applies across the Change Plan API, Customer Portal self-service changes, and scheduled changes
  - Previews return the exact amount the change charges
  - The localized price (and fees-inclusive behavior) carries into the new plan's renewals
  - Proration credits use what the customer actually paid for the old plan
  - Scheduled changes lock the price at scheduling time
  - The subscription's billing currency never changes; add-ons are not localized
- Updated the **All product types** row in Important Behaviors to link to the new section

English source only — translated locales are regenerated by the sync workflow.

`mint broken-links` passes (only pre-existing parse error in `de/features/entitlements/feature-flags.mdx`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)