### PR TITLE
fix(i18n): extend translation fixer to all locales + guard renameDir self-destruct

### DIFF
--- a/.github/workflows/fix-translations.yml
+++ b/.github/workflows/fix-translations.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       locale:
-        description: "Locale to repair. Supported (have passthrough detectors): zh-CN, ja, ko, ar, hi"
+        description: "Target locale to repair (any i18n.json target)"
         required: true
         default: "zh-CN"
         type: choice
@@ -18,6 +18,14 @@ on:
           - ko
           - ar
           - hi
+          - de
+          - es
+          - fr
+          - id
+          - it
+          - pt-BR
+          - sv
+          - vi
       concurrency:
         description: "Translation concurrency (Lingo max is 10)"
         required: false
@@ -54,8 +62,8 @@ jobs:
           CONCURRENCY: ${{ inputs.concurrency }}
           MAX_ATTEMPTS: ${{ inputs.max_attempts }}
         run: |
-          if ! printf '%s' "$LOCALE" | grep -qE '^(zh-CN|ja|ko|ar|hi)$'; then
-            echo "Unsupported locale: '$LOCALE' (supported: zh-CN, ja, ko, ar, hi)"; exit 1
+          if ! printf '%s' "$LOCALE" | grep -qE '^(ar|zh-CN|fr|de|es|hi|id|it|ja|ko|pt-BR|sv|vi)$'; then
+            echo "Unsupported locale: '$LOCALE' (must be an i18n.json target)"; exit 1
           fi
           if ! printf '%s' "$CONCURRENCY" | grep -qE '^([1-9]|10)$'; then
             echo "Invalid concurrency (1-10): '$CONCURRENCY'"; exit 1

--- a/i18n.json
+++ b/i18n.json
@@ -33,14 +33,22 @@
         "[locale]/miscellaneous/list-of-countries-we-accept-payments-from.mdx"
       ],
       "lockedPatterns": [
-        "<\\/?(?:Note|Tip|Warning|Info|Check|Steps|Step|Tabs|Tab|CodeGroup|Card|CardGroup|Accordion|AccordionGroup|Frame|Expandable|ResponseField|ParamField|RequestExample|ResponseExample|Tooltip|Update|Snippet|Icon)(?:\\s[^>]*)?\\/?>"
+        "<\\/?(?:Note|Tip|Warning|Info|Check|Steps|Step|Tabs|Tab|CodeGroup|Card|CardGroup|Accordion|AccordionGroup|Frame|Expandable|ResponseField|ParamField|RequestExample|ResponseExample|Tooltip|Update|Snippet|Icon)(?:\\s[^>]*)?\\/?>",
+        "\\bDodo(?:\\s+Payments)?\\b",
+        "Merchant of Record",
+        "\\bMoR\\b",
+        "Customer Portal",
+        "Adaptive Currency"
       ],
       "lockedKeys": ["tag", "openapi", "api", "icon"]
     }
   },
   "provider": {
     "id": "openai",
-    "model": "gpt-4o",
-    "prompt": "Act as a professional technical documentation translator. Translate the content from {source} to {target} while preserving all Markdown formatting, code blocks, links, frontmatter metadata, and Mintlify components. Do not translate or modify JSX/MDX component tags (e.g. <Note>, <Warning>, <Steps>, <Card>, <Accordion>, etc.) — keep tag names exactly as written. Do not change link destinations: keep every URL, path, anchor, and query string exactly as written. Only translate link text when needed, never the target. Maintain technical terminology appropriately (keep common technical terms in English when standard in the industry). Preserve code examples exactly as they are. Match the tone and formality of the source text. Do not invent or remove links."
+    "model": "gpt-5.6-luna",
+    "settings": {
+      "temperature": 1
+    },
+    "prompt": "You are a professional technical documentation translator for Dodo Payments. Translate the content from {source} to {target}. OUTPUT MUST REMAIN VALID MDX: preserve every Markdown structure and JSX/MDX component exactly; never add, remove, reorder, or rename tags, and always keep each opening tag paired with its matching closing tag (e.g. <Frame>...</Frame>, <Steps>...</Steps>, <Tabs>...</Tabs>, <CardGroup>...</CardGroup>). Never alter tag names, props, attribute values, or self-closing slashes. Keep all fenced code blocks, inline code, code inside components, URLs, paths, anchors, query strings, HTML entities, and frontmatter keys exactly as written; only translate human-readable link text, never the link target. DO NOT TRANSLATE — keep verbatim in English: the brand and product names 'Dodo Payments', 'Dodo', 'Merchant of Record', 'MoR', 'Customer Portal', 'Adaptive Currency'; code identifiers, API parameters and field names, environment variables, HTTP methods and status codes, and standard industry technical terms. Translate all other prose naturally and accurately into {target}, matching the tone and formality of the source. Do not invent, drop, or duplicate content or links. Return only the translated MDX with no explanations and no surrounding code fences."
   }
 }

--- a/scripts/fixTranslations.ts
+++ b/scripts/fixTranslations.ts
@@ -120,8 +120,16 @@ function expectedPages(srcBase) {
   return set;
 }
 
-// A page is "broken" when the target file is missing, or its prose is
-// overwhelmingly Latin with little/no native script (i.e. never translated).
+const squish = (s) => s.replace(/\s+/g, ' ').trim();
+
+// A page is "broken" when the target file is missing, or its prose was never
+// translated. Detection depends on the target script:
+//   - Non-Latin targets (cn/ja/ko/ar/hi): prose is overwhelmingly Latin with
+//     little/no native script.
+//   - Latin targets (de/es/fr/...): English and the target share an alphabet, so
+//     the only reliable passthrough signal is prose that is byte-identical to the
+//     English source after whitespace normalization. This catches full
+//     passthrough (the dominant failure) but not partial translations.
 function detectBroken(lingoCode, expected) {
   const mint = toMintlify(lingoCode);
   const langDir = path.join(ROOT, mint);
@@ -132,11 +140,15 @@ function detectBroken(lingoCode, expected) {
     if (!fs.existsSync(p)) { broken.push(rel); continue; }
     const prose = bodyProse(p);
     if (prose.trim().length < 150) continue; // API stubs / near-empty pages
-    const latin = (prose.match(/[A-Za-z]/g) || []).length;
-    if (!range) continue; // can't reliably score this script; skip
-    const native = (prose.match(range) || []).length;
-    const ratio = (native + latin) > 0 ? native / (native + latin) : 1;
-    if ((native < 5 && latin > 100) || (ratio < 0.25 && latin > 150)) broken.push(rel);
+    if (range) {
+      const latin = (prose.match(/[A-Za-z]/g) || []).length;
+      const native = (prose.match(range) || []).length;
+      const ratio = (native + latin) > 0 ? native / (native + latin) : 1;
+      if ((native < 5 && latin > 100) || (ratio < 0.25 && latin > 150)) broken.push(rel);
+    } else {
+      const enPath = path.join(ROOT, rel);
+      if (fs.existsSync(enPath) && squish(prose) === squish(bodyProse(enPath))) broken.push(rel);
+    }
   }
   return broken.sort();
 }
@@ -160,6 +172,10 @@ function moveBackFromEn() {
 }
 
 function renameDir(from, to) {
+  // No-op when the Mintlify folder name already equals the Lingo code (every
+  // locale except zh-CN). Without this guard, src === dst so the rmSync below
+  // would delete the folder we are about to "rename" onto itself, destroying it.
+  if (from === to) return;
   const src = path.join(ROOT, from);
   const dst = path.join(ROOT, to);
   if (!fs.existsSync(src)) return;
@@ -226,13 +242,10 @@ function intArg(argv, name, def) {
   return Number.isFinite(n) && n > 0 ? n : def;
 }
 
-function validateLocale(lingoCode) {
-  if (!fs.existsSync(I18N_PATH)) return;
+function i18nTargets() {
+  if (!fs.existsSync(I18N_PATH)) return [];
   const cfg = JSON.parse(fs.readFileSync(I18N_PATH, 'utf8'));
-  const targets = cfg?.locale?.targets || [];
-  if (!targets.includes(lingoCode)) {
-    console.warn(`[warn] "${lingoCode}" is not a target in i18n.json (${targets.join(', ')}).`);
-  }
+  return cfg?.locale?.targets || [];
 }
 
 function main() {
@@ -244,10 +257,9 @@ function main() {
   const maxAttempts = intArg(argv, '--max-attempts', 3);
   const concurrency = intArg(argv, '--concurrency', 8);
 
-  validateLocale(locale);
-
-  if (!SCRIPT_RANGES[mint]) {
-    console.error(`[error] No passthrough detector for "${mint}". Supported: ${Object.keys(SCRIPT_RANGES).join(', ')}.`);
+  const targets = i18nTargets();
+  if (targets.length && !targets.includes(locale)) {
+    console.error(`[error] "${locale}" is not a target in i18n.json. Valid: ${targets.join(', ')}.`);
     process.exitCode = 1;
     return;
   }


### PR DESCRIPTION
## Summary

Extends the automated translation fixer (`scripts/fixTranslations.ts` + `fix-translations.yml`) from the 5 non-Latin locales to **all 13 i18n targets**, and fixes a **critical folder-deletion bug** in `renameDir`.

## Critical bug fix: `renameDir` self-destruct

For every locale **except `zh-CN`**, the Mintlify folder name equals the Lingo code (`de`==`de`, `ja`==`ja`, …). So `renameDir(mint, locale)` was called with `src === dst`, and its `rmSync(dst)` **deleted the language folder** before the `renameSync` — wiping the entire target folder (reproduced locally: `de/` went 386 → 0 files). `zh-CN` was unaffected only because `cn` ≠ `zh-CN`.

Fix: `renameDir` now early-returns when `from === to`. Verified `de --skip-lingo` plumbing run: exit 0, `de` 386 → 386, `en/` staging cleaned up, no stray deletions.

## Other changes

- **Latin-target passthrough detection**: English and de/es/fr/… share an alphabet, so the native-script ratio check can't apply. Added a byte-identical-to-English (whitespace-normalized) prose comparison to catch full passthrough (the dominant failure mode).
- **Locale gate**: replaced the `SCRIPT_RANGES` restriction with validation against `i18n.json` targets, so any configured locale can be repaired.
- **Workflow**: expanded the `locale` choice list + validation regex to all 13 targets.
- **Model/prompt/terminology** (`i18n.json`): switched to `gpt-5.6-luna` (temperature 1), hardened the prompt for valid-MDX output, and locked brand/product terms (`Dodo Payments`, `Merchant of Record`, `MoR`, `Customer Portal`, `Adaptive Currency`) so they stay English.

## Testing

- `node --check scripts/fixTranslations.ts` ✅
- `node scripts/fixTranslations.ts --locale de --skip-lingo` → exit 0, no data loss, `en/` cleaned ✅
- `i18n.json` valid JSON; lockedPatterns regex sanity-checked ✅
- Invalid locale correctly rejected ✅

## Notes

Follows the merged zh-CN work (#408–#411; zh-CN now 386/387). After merge, the fixer workflow will be dispatched for the remaining 12 locales (measured broken counts: ja 41, ko 44, ar 47, hi 44, de 18, es 20, fr 21, id 18, it 18, pt-BR 19, sv 20, vi 22).