### PR TITLE
fix(i18n): drop brand-term lockedPatterns that broke YAML frontmatter

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -33,12 +33,7 @@
         "[locale]/miscellaneous/list-of-countries-we-accept-payments-from.mdx"
       ],
       "lockedPatterns": [
-        "<\\/?(?:Note|Tip|Warning|Info|Check|Steps|Step|Tabs|Tab|CodeGroup|Card|CardGroup|Accordion|AccordionGroup|Frame|Expandable|ResponseField|ParamField|RequestExample|ResponseExample|Tooltip|Update|Snippet|Icon)(?:\\s[^>]*)?\\/?>",
-        "\\bDodo(?:\\s+Payments)?\\b",
-        "Merchant of Record",
-        "\\bMoR\\b",
-        "Customer Portal",
-        "Adaptive Currency"
+        "<\\/?(?:Note|Tip|Warning|Info|Check|Steps|Step|Tabs|Tab|CodeGroup|Card|CardGroup|Accordion|AccordionGroup|Frame|Expandable|ResponseField|ParamField|RequestExample|ResponseExample|Tooltip|Update|Snippet|Icon)(?:\\s[^>]*)?\\/?>"
       ],
       "lockedKeys": ["tag", "openapi", "api", "icon"]
     }


### PR DESCRIPTION
## Summary

Fixes the deterministic root cause behind the 12 translation misses on `cli.mdx` (7 locales) and `mor-introduction.mdx` (5 locales).

## Root cause

The brand-term `lockedPatterns` added in #412 caused lingo.dev to fail these files. lingo replaces each match with a `{/* LOCKED_PATTERN_<hash> */}` placeholder and **re-serializes the YAML frontmatter**. When a brand term is the first token of a `title`/`description` value, the re-serialized scalar begins with `{`, which YAML parses as a flow-mapping and rejects:

```
❌ cli.mdx  Unexpected scalar at node end at line 1, column 64:
            title: {/* LOCKED_PATTERN_45d5... */} CLI       (source: title: "Dodo CLI")
❌ mor-introduction.mdx  line 3, column 70:
            ...*/} acts as your {/* ... */}                 (source: description: "Dodo Payments acts as your Merchant of Record...")
```

lingo then fails the whole file and leaves it English — which is exactly why these two pages never translated across every locale and all 3 retry attempts. Source quoting doesn't help because lingo re-serializes the parsed scalar.

## Fix

Remove the 5 brand-term patterns (`Dodo Payments`, `Merchant of Record`, `MoR`, `Customer Portal`, `Adaptive Currency`). The hardened provider prompt already lists all of them as do-not-translate, so term preservation is retained without the frontmatter breakage. The essential JSX-component-tag `lockedPattern` stays.

## Follow-up

After merge, re-run the fixer workflow for the affected locales (de, id, it, ko, hi, sv, vi, ja, ar, pt-BR). Post-run verification will confirm the pages translate and brand terms stay English.