### PR TITLE
docs: backfill feature docs for v1.109.0 release

### DIFF
--- a/api-reference/error-codes.mdx
+++ b/api-reference/error-codes.mdx
@@ -448,7 +448,7 @@ These errors relate to merchant-owned payment connectors (Bring Your Own Process
   - **Message:** Minimum amount of {display_str} is required to process payment
 
 - `UNSUPPORTED_BILLING_CURRENCY`
-  - **Trigger:** Subscriptions restricted to USD
+  - **Trigger:** The requested billing currency is not supported for this subscription
   - **Message:** Non USD billing currency is not supported for subscriptions
 
 - `UNSUPPORTED_COUNTRY`
@@ -456,8 +456,8 @@ These errors relate to merchant-owned payment connectors (Bring Your Own Process
   - **Message:** Country {country_name} currently not supported
 
 - `UNSUPPORTED_CURRENCY`
-  - **Trigger:** Product or addon currency invalid
-  - **Message:** Currency is not currently supported / Only USD and INR products supported currently / Only USD and INR supported for addon price / Can only request USD or INR for billing_currency / Currency Not Supported / Unexpected currency for Indian card subscripitons
+  - **Trigger:** Product or addon currency is not a currency Dodo Payments can charge in. Base prices can be set in any chargeable currency, so this usually means the currency code is invalid or not yet supported.
+  - **Message:** Currency is not currently supported / Only USD and INR products supported currently / Only USD and INR supported for addon price / Can only request USD or INR for billing_currency / Currency Not Supported / Unexpected currency for Indian card subscriptions
 
 - `UNSUPPORTED_TAX_CATEGORY`
   - **Trigger:** Tax category string not in enum

--- a/developer-resources/checkout-session.mdx
+++ b/developer-resources/checkout-session.mdx
@@ -752,6 +752,8 @@ Additional configuration for checkout sessions containing subscription products.
 <Expandable title="Subscription data object properties">
 <ParamField body="trial_period_days" type="integer">
 Number of days for the trial period before the first charge. Must be between 0 and 10000 days.
+
+A paid trial amount cannot be set per session — configure `trial_amount` on the product's recurring price instead. See [Paid Trials](/features/subscription#paid-trials).
 </ParamField>
 
 <ParamField body="on_demand" type="object">
@@ -1288,6 +1290,10 @@ Before creating a checkout session, you can preview the pricing breakdown includ
 
 <Note>
 When the cart contains a subscription product, the preview response also returns a `next_billing_date` — a preview of the upcoming billing date, so you can show it before the subscription is created. It is computed relative to now: `now + trial period` when a trial applies, otherwise `now + one payment frequency`. The field is omitted for one-time-only carts. This is an estimate anchored on the preview time; the authoritative `next_billing_date` is set when the subscription activates.
+</Note>
+
+<Note>
+The preview also returns `trial_period_days` (the effective trial length, free or paid) and `trial_amount` (the per-unit trial charge after discounts, in the price currency's minor units). `trial_amount` is only present for a [paid trial](/features/subscription#paid-trials) and is `null` for a free trial or no trial. Use `current_breakup` for the taxed total actually due today.
 </Note>
 
 <Tabs>

--- a/features/adaptive-currency.mdx
+++ b/features/adaptive-currency.mdx
@@ -12,9 +12,9 @@ Adaptive Currency lets you show localized prices and accept payments in customer
 
 ## What Is Adaptive Currency?
 
-Adaptive Currency displays product prices in the customer's local currency instead of a fixed global currency (for example, USD). When enabled, checkout defaults to the detected local currency for supported countries, with the option to switch to USD.
+Adaptive Currency displays product prices in the customer's local currency instead of only your base currency. When enabled, checkout defaults to the detected local currency for supported countries, with the option to switch back to your base currency.
 
-Adaptive Currency converts your base price at live exchange rates. To set your own fixed price per currency or country instead, see [Localized Pricing](/features/localized-pricing).
+Your base currency is whatever you priced the product or add-on in — it can be any currency Dodo Payments can charge, not just USD. Adaptive Currency converts that base price at live exchange rates. To set your own fixed price per currency or country instead, see [Localized Pricing](/features/localized-pricing).
 
 ## Key Benefits
 
@@ -53,7 +53,7 @@ Verify a test checkout shows prices in your local currency when supported.
 ## Customer Experience
 
 1. **Detection**: The system detects the customer's country based on the billing address.
-2. **Currency selection**: If the country is supported, prices show in the local currency by default. Customers can switch to USD.
+2. **Currency selection**: If the country is supported, prices show in the local currency by default. Customers can switch back to your base currency.
 3. **Payment methods**: Localized payment methods appear where applicable.
 4. **Checkout**: Payment is completed in the selected currency.
 
@@ -196,7 +196,7 @@ When a [Localized Pricing](/features/localized-pricing) rule matches, the transa
 
 ## Refunds and Adjustments
 
-Dodo Payments issues refunds in the currency the customer originally paid, using the latest exchange rate. The global USD amount remains fixed on your dashboard, invoices, and in the refund. This means the customer may receive more or less than the original local‑currency amount depending on FX changes.
+Dodo Payments issues refunds in the currency the customer originally paid, using the latest exchange rate. The amount in your base currency remains fixed on your dashboard, invoices, and in the refund. This means the customer may receive more or less than the original local‑currency amount depending on FX changes.
 
 <Info>
 Adaptive Currency fees which are generally the FX fees are not refunded.

--- a/features/addons.mdx
+++ b/features/addons.mdx
@@ -59,6 +59,7 @@ Add-ons are created as separate products in your Dodo Payments dashboard and the
 When creating add-ons, you can configure:
 
 - **Pricing**: Set one-time or recurring pricing for the add-on
+- **Currency**: Set the base price in any currency Dodo Payments can charge. The searchable currency selector pins **USD, GBP, EUR, and INR** to the top; customers outside your base currency are billed through [Adaptive Currency](/features/adaptive-currency)
 - **Billing cycle**: Must match your subscription's billing cycle
 - **Quantity limits**: Set minimum and maximum quantities per customer
 - **Availability**: Control which subscription products can use the add-on

--- a/features/design.mdx
+++ b/features/design.mdx
@@ -12,7 +12,7 @@ keywords: ["Dodo Payments", "design & theme customization", "payment platform", 
 </Frame>
 
 <Info>
-The Design page is your central hub for branding every customer-facing surface: checkout, storefront, and customer portal. Changes apply instantly across all three and are previewed in real time before you save.
+The Design page is your central hub for branding every customer-facing surface: checkout, storefront, and customer portal. Changes apply instantly across all three and are previewed in real time before you save. Test mode and live mode hold separate designs — see [Copy Design From Test to Live Mode](#copy-design-from-test-to-live-mode).
 </Info>
 
 ## Key Highlights
@@ -23,6 +23,7 @@ The Design page is your central hub for branding every customer-facing surface: 
 4. **Live Preview** - See how your changes look across checkout, customer portal, and storefront before saving.
 5. **Per-Section Overrides** - Fine-tune individual sections (checkout, storefront, customer portal) without affecting the others.
 6. **Programmatic Control** - Override themes at checkout time via the API or Checkout SDK.
+7. **Copy Test Design to Live** - Move a design you perfected in test mode into live mode in one step.
 
 ## Getting Started
 
@@ -215,6 +216,16 @@ Override the theme for the customer portal, which includes:
 - Billing history
 - Payment methods
 - Wallet and credits
+
+## Copy Design From Test to Live Mode
+
+Test mode and live mode keep separate design configurations, so a theme you build while testing does not automatically appear to real customers. Instead of re-creating it by hand, copy your design from test mode to live mode in one step.
+
+The copy covers **all design surfaces** — general settings, checkout, customer portal, and storefront overrides — along with your storefront branding.
+
+<Warning>
+Copying overwrites the existing live mode design. Review your live checkout and storefront after copying to confirm everything looks the way you expect.
+</Warning>
 
 ## Related Resources
 

--- a/features/payouts/payout-structure.mdx
+++ b/features/payouts/payout-structure.mdx
@@ -137,17 +137,22 @@ You will see the updated amount in the Minimum Payout Threshold field
 This feature applies to the USD/EUR/GBP wallets.
 </Note>
 
-## Payout Bank Accounts
+## Payout Accounts
 
-Manage the bank accounts that receive your payouts directly from the **Payouts** page under **Linked Bank Accounts**.
+Manage the bank accounts that receive your payouts directly from the **Payouts** page under **Linked Bank Accounts**. You can maintain **multiple payout accounts** rather than a single fixed one, adding an account per **currency** and **transfer method**.
 
-- You can submit up to **3 bank accounts** per business.
-- Once an account is **verified**, you can set it as your **primary** account.
-- The **primary** account is the one used at the time of payout.
+- **Add an account** for the currency and transfer method you want to be paid in.
+- **Save a draft** if you do not have every detail on hand, and finish the submission later.
+- **Resubmit** an account placed on hold. The hold or failure reason is shown inline on the account so you know exactly what to correct.
+- The **first approved account is activated automatically**. Only the active account receives payouts.
 
 <Info>
-Only the primary account receives payouts. Additional verified accounts remain available so you can switch your primary account whenever needed.
+Additional approved accounts remain available so you can switch the active account whenever you need to, for example when you start receiving payouts in a different currency.
 </Info>
+
+<Note>
+Bank verification during business onboarding is driven by the same payout accounts flow, so the account you submit while onboarding appears on the **Payouts** page as your first payout account. See [Account Verification](/miscellaneous/verification-process).
+</Note>
 
 <Warning>
 Bank account details must match your verified identity or registered entity name. Dodo Payments cannot process payouts to mismatched or third-party accounts. See [Account Verification](/miscellaneous/verification-process) for the full name-matching rules.

--- a/features/product-collections.mdx
+++ b/features/product-collections.mdx
@@ -191,9 +191,14 @@ Configure how subscriptions and plan changes work across your business from **Se
 |---------|-------------|---------|
 | **Allow Multiple Subscriptions** | Customers can hold more than one active subscription at the same time | Enabled |
 | **Allow Subscription Updates** | Customers can upgrade or downgrade their existing subscriptions anytime via Customer Portal | Disabled |
+| **Prevent Trial Misuse** | Customers who have already redeemed a trial are degraded to a paid, no-trial purchase instead of receiving a fresh trial | Disabled |
 
 <Info>
 Plan changes via Customer Portal are disabled by default. Enable "Allow Subscription Updates" in **Settings → Subscriptions** to let customers upgrade or downgrade between products in the same collection.
+</Info>
+
+<Info>
+For details on how trial redemptions are matched and recorded, see [Preventing Trial Misuse](/features/subscription#preventing-trial-misuse).
 </Info>
 
 <Card title="Subscription Plan Changes" icon="repeat" href="/features/subscription#subscription-plan-changes">

--- a/features/products.mdx
+++ b/features/products.mdx
@@ -50,9 +50,13 @@ Select the pricing model:
 
 Then set pricing:
 
-- **Price**: Base amount and currency.
+- **Price**: Base amount and currency. You can set the base price in **any currency Dodo Payments can charge**, not just USD. Use the searchable currency selector to find a currency; **USD, GBP, EUR, and INR** are pinned to the top of the list.
 - **Discount (%)**: Optional inline discount shown in checkout and invoices.
-- For subscriptions, set **Repeat every** (e.g., 1 month or 1 year) and **Trial days** if needed. The subscription price must be at least **$1** (or the equivalent in your chosen currency); amounts below this minimum are not supported and the subscription will not work.
+- For subscriptions, set **Repeat every** (e.g., 1 month or 1 year), **Trial days**, and an optional **Trial amount** for a [paid trial](/features/subscription#paid-trials). The subscription price must be at least **$1** (or the equivalent in your chosen currency); amounts below this minimum are not supported and the subscription will not work.
+
+<Info>
+Customers outside your base currency are still billed through [Adaptive Currency](/features/adaptive-currency), so you can author prices in whichever currency best fits your market without changing how buyers are charged.
+</Info>
 
 <Tip>
 Want a fixed price per currency or country instead of a live FX conversion? Set a `pricing_mode` on the product and attach [Localized Pricing](/features/localized-pricing) rules — for example €9.99 in EUR or ₹999 in India.
@@ -112,6 +116,11 @@ You can manage products through the dashboard or programmatically via API. The A
 
 - **Update**: Edit name, description, images, price, fields, and benefits at any time (pricing model is immutable).
 - **Archive**: Hide a product from new purchases without disrupting existing customers. You can unarchive later.
+- **Drafts**: An in-progress product is saved as a draft so you can return to it later. Drafts are kept **separately for test mode and live mode**, so an unfinished product in one mode never bleeds into the other. Use **Clear Draft** to discard it and start fresh.
+
+<Tip>
+Product and collection form pages include header action buttons, so you can save without scrolling to the bottom of a long form.
+</Tip>
 
 ### API Management
 

--- a/features/storefront.mdx
+++ b/features/storefront.mdx
@@ -60,6 +60,8 @@ Test Mode and Live Mode have separate storefronts. You can see the test mode ind
 
 Test Mode is for you try out the user flow and purchase experience on the store. Please share the live mode Store link with your users to facilitate real purchases
 
+Once you are happy with how your store looks in test mode, you can copy the design and storefront branding straight into live mode instead of rebuilding it. See [Copy Design From Test to Live Mode](/features/design#copy-design-from-test-to-live-mode).
+
 
 
 ## Customer Experience

--- a/features/subscription.mdx
+++ b/features/subscription.mdx
@@ -75,6 +75,7 @@ Pick the most accurate tax category to ensure correct tax collection per region.
 - **Repeat payment every** (required): Interval for renewals, e.g., every 1 Month. Select the cadence (months or years) and quantity.
 - **Subscription Period** (required): Total term for which the subscription remains active (e.g., 10 Years). After this period ends, renewals stop unless extended.
 - **Trial Period Days** (required): Set trial length in days. Use 0 to disable trials. The first charge occurs automatically when the trial ends.
+- **Trial Amount**: Optional upfront charge for a paid trial. Leave it unset for a free trial. See [Paid Trials](#paid-trials).
 - **Select add‑on**: Attach up to 10 add‑ons that customers can purchase alongside the base plan.
 
 <Warning>
@@ -98,7 +99,7 @@ Use metadata to store identifiers from your system (e.g., accountId) so you can 
 
 ## Subscription Trials
 
-Trials let customers access subscriptions without immediate payment. The first charge occurs automatically when the trial ends.
+Trials let customers evaluate a subscription before paying the full recurring price. A trial can be **free**, where nothing is charged until the trial ends, or **paid**, where a reduced amount is charged upfront. In both cases the full price begins at the first renewal after the trial ends.
 
 ### Configuring Trials
 
@@ -123,13 +124,71 @@ const session = await client.checkoutSessions.create({
 The `trial_period_days` value must be between 0 and 10,000 days.
 </Warning>
 
+### Paid Trials
+
+Trials do not have to be free. Set a **Trial Amount** on a subscription product's recurring price to charge a reduced upfront fee for the trial window. The full recurring price then takes over at the first renewal.
+
+<Frame>
+<img src="/images/subscriptions/paid-trials.png" alt="Subscription pricing form with a trial duration and an optional trial amount for a paid trial" style={{ maxHeight: '500px', width: 'auto' }} />
+</Frame>
+
+Paid trials are configured on the product's price, not per subscription or per checkout session:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trial_amount` | integer | Amount charged today for the trial, in the price currency's minor units (for example, `500` for $5.00). Requires `trial_period_days > 0`. Omit or set to `null` for a free trial. |
+| `trial_apply_discounts` | boolean | Whether checkout discount codes reduce the trial charge. Defaults to `false`, so the trial amount is charged in full even when a discount applies to the recurring price. |
+
+```typescript
+const product = await client.products.create({
+  name: 'Pro Plan',
+  tax_category: 'saas',
+  price: {
+    type: 'recurring_price',
+    price: 2900,                      // $29.00 per month after the trial
+    currency: 'USD',
+    payment_frequency_count: 1,
+    payment_frequency_interval: 'Month',
+    subscription_period_count: 1,
+    subscription_period_interval: 'Year',
+    trial_period_days: 14,            // A paid trial requires a positive trial period
+    trial_amount: 500,                // $5.00 charged today
+    trial_apply_discounts: false      // Discounts apply to the recurring price only
+  }
+});
+```
+
+Paid trials flow through checkout as well. The trial amount is taxed, surfaced in checkout session calculations and payment link pricing, and Adaptive Currency markup is applied per currency. The [preview endpoint](/developer-resources/checkout-session) returns `trial_amount` and `trial_period_days` so you can show the amount due today before the subscription is created.
+
+<Info>
+Free trials are unchanged. Leaving **Trial Amount** unset keeps the existing behavior, where the first charge is `0` and the full price is charged when the trial ends.
+</Info>
+
+### Preventing Trial Misuse
+
+**Prevent Trial Misuse** stops customers from repeatedly claiming trials for the same business. When enabled, a customer who has already redeemed a trial is automatically degraded to a **paid, no-trial purchase** instead of receiving a fresh trial.
+
+<Frame>
+<img src="/images/subscriptions/prevent-trial-misuse.png" alt="Prevent Trial Misuse toggle in the Subscriptions settings tab" style={{ maxHeight: '500px', width: 'auto' }} />
+</Frame>
+
+Enable it from the **Subscriptions** tab in **Settings**. Once enabled:
+
+- Customers are matched by **normalized email**, with plus-aliases stripped, so `user+trial@example.com` and `user@example.com` count as the same person.
+- Redemptions are recorded at **trial activation**, so a customer who cancels the same day has still consumed their trial.
+- Existing customers are backfilled from their historical trials by email, so past trial users are recognized immediately.
+
+<Info>
+The setting is **off by default**. See [Subscription Settings](/features/product-collections#subscription-settings) for the full list of business-level subscription controls.
+</Info>
+
 ### Detecting Trial Status
 
 <Warning>
 Currently, there is no direct field to detect trial status. The following is a workaround that requires querying payments, which is inefficient. We are working on a more efficient solution.
 </Warning>
 
-To determine if a subscription is in trial, retrieve the list of payments for the subscription. If there is exactly one payment with amount 0, the subscription is in trial period:
+To determine if a **free trial** subscription is in trial, retrieve the list of payments for the subscription. If there is exactly one payment with amount 0, the subscription is in trial period:
 
 ```typescript
 const subscription = await client.subscriptions.retrieve('sub_123');
@@ -141,6 +200,10 @@ const payments = await client.payments.list({
 const isInTrial = payments.items.length === 1 && 
                   payments.items[0].total_amount === 0;
 ```
+
+<Warning>
+This zero-amount check only works for free trials. For a [paid trial](#paid-trials) the first payment equals the trial amount, not `0`. Compare the first payment against the subscription's `trial_amount` instead, or check whether `next_billing_date` is still within the trial window.
+</Warning>
 
 ### Updating Trial Period
 

--- a/miscellaneous/faq.mdx
+++ b/miscellaneous/faq.mdx
@@ -96,7 +96,7 @@ You can refer to /miscellaneous/accounts#managing-multiple-businesses for more d
   A: No, Dodo Payments currently does not support physical goods and does not offer a Shopify plugin.
 </Accordion>
 <Accordion title="Q20: My INR subscription product is showing USD on checkout. How do I fix that?">
-  A: Our subscription products are managed in USD by default. To display prices in the customer's local currency and enable the corresponding payment methods, you need to enable Adaptive Pricing.
+  A: You can set a product's base price in any currency Dodo Payments can charge, so check that the product's base currency is INR. Customers outside your base currency are billed via Adaptive Pricing, so enable Adaptive Pricing to display prices in the customer's local currency and unlock the corresponding payment methods.
 </Accordion>
 
 <Accordion title="Q21: How do I update my brand URL for secondary brands?">
@@ -681,12 +681,10 @@ POST /subscriptions/{subscription_id}/change-plan
 </Accordion>
 
 <Accordion title="Q103: I submitted the wrong bank account details. How do I update them?">
-  A: If you've entered incorrect bank details:
-  - Contact support via Intercom or Mail.
-  - Wait for the compliance team to reopen the section for you to re-submit.
+  A: Go to the **Payouts** page and open the account under **Linked Bank Accounts**. Accounts placed on hold or marked failed show the reason inline and offer a **resubmit** action, so you can correct the details yourself. You can also add a new payout account and activate it instead.
 
   <Note>
-  Editing bank details directly in the dashboard may not be allowed post-submission.
+  If the account is not resubmittable from the dashboard, contact support via Intercom or Mail and the compliance team will reopen the section for you. See [Payout Accounts](/features/payouts/payout-structure#payout-accounts).
   </Note>
 </Accordion>
 


### PR DESCRIPTION
Audited every item in `changelog/v1.109.0.mdx` against the English feature docs and the OpenAPI spec, then documented the gaps and corrected statements the release made stale.

## Audit result

| Changelog item | Status before | Action |
|---|---|---|
| 1. Analytics v3 | Already documented (#439) | none |
| 2. Paid Trials | **Undocumented** (spec-only) | documented |
| 3. Prevent Trial Misuse | **Undocumented** | documented |
| 4. Payout Accounts | **Docs described the old single/primary-account model** | rewritten |
| 5. Pricing in any chargeable currency | **Undocumented + stale USD-only claims** | documented + corrected |
| 6. `subscription.update_payment_method` | Already documented | none |
| 7. Native social login (mobile) | Undocumented | skipped, see below |
| 8. `next_billing_date` in preview | Already documented | extended |
| 9. `cancel_at_next_billing_date` filter | Renders from OpenAPI stub | none |
| 10. Copy design test → live | **Undocumented** | documented |
| 11. Per-mode product drafts | **Undocumented** | documented |
| 12. Selectable table columns | Undocumented | skipped, see below |
| 13. Keyboard accessibility | Undocumented | skipped, see below |

## Changes

**Paid trials** — `features/subscription.mdx`
- New `### Paid Trials` section with the `paid-trials.png` screenshot, a field table for `trial_amount` / `trial_apply_discounts` (wording taken from the `RecurringPrice` schema), and a product-create example.
- Reworded the section intro, which claimed trials always mean "without immediate payment".
- Added a **Trial Amount** bullet to the pricing field list.
- Flagged that the "exactly one payment with amount 0" trial-detection workaround only holds for free trials — for a paid trial the first payment equals the trial amount.

**Prevent trial misuse** — `features/subscription.mdx`, `features/product-collections.mdx`
- New `### Preventing Trial Misuse` section with the settings screenshot, covering normalized-email matching, recording at trial activation, and backfill.
- Added the toggle to the **Settings → Subscriptions** table (default: Disabled) with a cross-link.

**Payout accounts** — `features/payouts/payout-structure.mdx`, `miscellaneous/faq.mdx`
- Replaced the "up to 3 accounts, verify then set primary" model with the current one: multiple accounts per currency and transfer method, drafts, inline hold/failure reasons with resubmit, and first-approved-account auto-activation.
- Noted that onboarding bank verification now runs through the same flow.
- FAQ Q103 previously said editing bank details post-submission "may not be allowed" and to wait on compliance; it now points at the self-serve resubmit action.

**Any chargeable currency** — `features/products.mdx`, `features/addons.mdx`, `features/adaptive-currency.mdx`, `miscellaneous/faq.mdx`, `api-reference/error-codes.mdx`
- Documented the searchable currency selector and the USD/GBP/EUR/INR pinned entries for both products and add-ons.
- Adaptive Currency assumed USD was always the base ("option to switch to USD", "the global USD amount remains fixed"); reframed around *your base currency*.
- FAQ Q20 said "our subscription products are managed in USD by default" — corrected.
- `UNSUPPORTED_BILLING_CURRENCY` / `UNSUPPORTED_CURRENCY` triggers no longer assert a USD-only restriction. (Also fixed the `subscripitons` typo.)

**Design & products**
- New `## Copy Design From Test to Live Mode` in `features/design.mdx`, covering all design surfaces plus storefront branding, with a warning that it overwrites live. Cross-linked from `features/storefront.mdx`.
- Per-mode drafts + **Clear Draft** + header action buttons in `features/products.mdx`.

**Checkout session** — `developer-resources/checkout-session.mdx`
- Preview note now covers `trial_amount` and `trial_period_days`, not just `next_billing_date`.
- Clarified in `subscription_data.trial_period_days` that a paid trial amount is a product-price setting and cannot be set per session.

## Notes for reviewers

- **Please confirm the payout account limit.** The old copy claimed a hard cap of 3 bank accounts per business. The changelog describes accounts added per currency and transfer method, which makes a flat cap of 3 doubtful, so I dropped the number rather than restate it. If a cap still applies, say what it is and I'll add it back.
- **Three items intentionally left undocumented**: native social login in the mobile app (`features/mobile-app.mdx` has no auth section at all — adding one is its own piece of work), selectable list-API table columns, and the keyboard accessibility pass. None have a natural home today; happy to add pages if you want them covered.
- **Not covered**: `cancel_at_next_billing_date` as a *list filter* has no prose anywhere, but `api-reference/subscriptions/get-subscriptions-1` renders it straight from the spec, so I left it.
- **Translations untouched** per AGENTS.md — the 13 locale folders need a `Sync Languages` run after this merges. `miscellaneous/faq.mdx` is excluded from translation, so those edits carry no sync cost.

## Validation

`mint validate` → `success build validation passed`. All new cross-link anchors verified against their headings.


---
*Created with [Squirrels](https://squirrels.dodopayments.tech/session/8dcf06e7bc6372e4c2ca5550619d6f9c)*