### PR TITLE
docs(sdks): add per-platform mobile checkout SDK pages and fix Flutter coverage

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -6,9 +6,15 @@ keywords: ["Dodo Payments", "API reference", "REST API", "introduction"]
 ---
 
 
+<CardGroup cols={2}>
 <Card title="SDKs & Libraries" icon="code" href="/developer-resources/dodo-payments-sdks">
-Accelerate your integration by using official SDKs for <strong>TypeScript</strong>, <strong>Python</strong>, <strong>Go</strong>, <strong>PHP</strong>, <strong>Java</strong>, <strong>Kotlin</strong>, <strong>C#</strong>, <strong>Ruby</strong>, and <strong>React Native</strong>. These libraries simplify API requests, authentication, and error handling, letting you focus on building great payment experiences.
+Official backend SDKs for <strong>TypeScript</strong>, <strong>Python</strong>, <strong>Go</strong>, <strong>PHP</strong>, <strong>Java</strong>, <strong>Kotlin</strong>, <strong>C#</strong>, <strong>Ruby</strong>, and <strong>Rust</strong>. These libraries simplify API requests, authentication, and error handling, letting you focus on building great payment experiences.
 </Card>
+
+<Card title="Mobile Checkout SDKs" icon="mobile" href="/developer-resources/mobile-integration">
+Building a native app? Open Dodo's hosted checkout and get a typed result back in one call, on <strong>Android</strong>, <strong>iOS</strong>, <strong>React Native</strong>, and <strong>Flutter</strong>. These hold no API key.
+</Card>
+</CardGroup>
 
 ## Environment URLs
 

--- a/community/projects.mdx
+++ b/community/projects.mdx
@@ -7,6 +7,12 @@ keywords: ["Dodo Payments", "community", "open source", "developer ecosystem", "
 
 Browse community projects by category. Each card links directly to the repository.
 
+<Info>
+These are built and maintained by the community, not by Dodo Payments. For
+first-party, supported libraries — including the official Flutter checkout SDK
+(`dodopayments_checkout`) — see [Official SDKs](/developer-resources/dodo-payments-sdks).
+</Info>
+
 <Tabs>
 <Tab title="Libraries & SDKs">
   <CardGroup cols={1}>
@@ -44,6 +50,7 @@ Browse community projects by category. Each card links directly to the repositor
     <Card title="Dodo Payments Flutter SDK (Dart)" href="https://github.com/MrPrinceRawat/dodopayments-flutter" icon="mobile">
       Flutter/Dart SDK for Dodo Payments with full API coverage.
       <br/>20 resources, 60+ methods, typed models, and a drop-in DodoCheckoutButton widget with WebView.
+      <br/><br/>Distinct from the official <a href="/developer-resources/sdks/flutter">Flutter checkout SDK</a>, which is checkout-only and opens a native browser surface instead of a WebView.
       <br/><br/>By <a href="https://github.com/MrPrinceRawat">@MrPrinceRawat</a>
       <br/><br/>`Dart` `Flutter` `SDK`
     </Card>

--- a/community/projects.mdx
+++ b/community/projects.mdx
@@ -7,12 +7,6 @@ keywords: ["Dodo Payments", "community", "open source", "developer ecosystem", "
 
 Browse community projects by category. Each card links directly to the repository.
 
-<Info>
-These are built and maintained by the community, not by Dodo Payments. For
-first-party, supported libraries — including the official Flutter checkout SDK
-(`dodopayments_checkout`) — see [Official SDKs](/developer-resources/dodo-payments-sdks).
-</Info>
-
 <Tabs>
 <Tab title="Libraries & SDKs">
   <CardGroup cols={1}>
@@ -50,7 +44,6 @@ first-party, supported libraries — including the official Flutter checkout SDK
     <Card title="Dodo Payments Flutter SDK (Dart)" href="https://github.com/MrPrinceRawat/dodopayments-flutter" icon="mobile">
       Flutter/Dart SDK for Dodo Payments with full API coverage.
       <br/>20 resources, 60+ methods, typed models, and a drop-in DodoCheckoutButton widget with WebView.
-      <br/><br/>Distinct from the official <a href="/developer-resources/sdks/flutter">Flutter checkout SDK</a>, which is checkout-only and opens a native browser surface instead of a WebView.
       <br/><br/>By <a href="https://github.com/MrPrinceRawat">@MrPrinceRawat</a>
       <br/><br/>`Dart` `Flutter` `SDK`
     </Card>

--- a/developer-resources/checkout-session.mdx
+++ b/developer-resources/checkout-session.mdx
@@ -302,7 +302,7 @@ window.open(session.checkout_url, '_blank');
 ```
 
 <Tip>
-**Alternative Integration Options**: Instead of redirecting, you can embed the checkout directly in your page using [Overlay Checkout](/developer-resources/overlay-checkout) (modal overlay) or [Inline Checkout](/developer-resources/inline-checkout) (fully embedded). Both options use the same checkout session URL.
+**Alternative Integration Options**: Instead of redirecting, you can embed the checkout directly in your page using [Overlay Checkout](/developer-resources/overlay-checkout) (modal overlay) or [Inline Checkout](/developer-resources/inline-checkout) (fully embedded). In a native mobile app, hand the same URL to the [Mobile Checkout SDKs](/developer-resources/mobile-integration) for Android, iOS, React Native, or Flutter. All of these consume the same checkout session URL.
 </Tip>
 </Step>
 
@@ -681,7 +681,7 @@ Allow customers to edit the zipcode during checkout.
 Skip the default payment success page and redirect customers immediately to your `return_url` after payment completion.
 
 <Tip>
-Use this when you have a custom success page that provides a better user experience, or for mobile apps and embedded checkout flows.
+Use this when you have a custom success page that provides a better user experience, or for [mobile apps](/developer-resources/mobile-integration) and embedded checkout flows.
 </Tip>
 </ParamField>
 </Expandable>
@@ -1192,7 +1192,7 @@ const session = await client.checkoutSessions.create({
 ```
 
 <Tip>
-Use `redirect_immediately: true` when you have a custom success page that provides better user experience than the default payment success page. This is especially useful for mobile apps and embedded checkout flows.
+Use `redirect_immediately: true` when you have a custom success page that provides better user experience than the default payment success page. This is especially useful for [mobile apps](/developer-resources/mobile-integration) and embedded checkout flows.
 </Tip>
 
 <Note>

--- a/developer-resources/dodo-payments-sdks.mdx
+++ b/developer-resources/dodo-payments-sdks.mdx
@@ -58,16 +58,8 @@ Choose the SDK that matches your tech stack:
 </Card>
 </CardGroup>
 
-### Mobile Checkout SDKs
-
-For hosted-checkout integrations on mobile, we also provide a family of
-lightweight checkout SDKs for Swift, Kotlin, and React Native. One call
-opens Dodo's hosted checkout in the platform's native browser surface and
-returns a typed result.
-
-<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
-  Install steps and usage for the Swift, Kotlin, and React Native checkout SDKs
-</Card>
+Building a mobile app? See [Mobile Checkout SDKs](#mobile-checkout-sdks) below
+for Android, iOS, React Native, and Flutter.
 
 ## Quick Start
 
@@ -179,15 +171,32 @@ All SDKs share these core capabilities:
 ## Mobile Checkout SDKs
 
 If you'd rather open Dodo's **hosted checkout page** than build a native
-payment sheet, use the mobile checkout SDK for your platform instead. All
-three share the same one-call contract: `start(...)` returns a typed
-`CheckoutResult`, none of them hold an API key, and Apple Pay/Google Pay
-work the same way they do on the open web since checkout opens in the
-platform's real browser surface (`SFSafariViewController` / Custom Tabs),
-not a `WebView`:
+payment sheet, use the mobile checkout SDK for your platform. All four share
+the same one-call contract: `start(...)` returns a typed `CheckoutResult`,
+none of them hold an API key, and Apple Pay/Google Pay work the same way they
+do on the open web since checkout opens in the platform's real browser surface
+(`SFSafariViewController` / Custom Tabs), not a `WebView`:
+
+<CardGroup cols={2}>
+<Card title="Android" icon="android" href="/developer-resources/sdks/android">
+  Kotlin SDK that opens a Chrome Custom Tab. Requires `minSdk` 23
+</Card>
+
+<Card title="iOS" icon="apple" href="/developer-resources/sdks/ios">
+  Swift SDK that opens `SFSafariViewController`. Requires iOS 16+
+</Card>
+
+<Card title="React Native" icon="react" href="/developer-resources/sdks/react-native">
+  Turbo Module over both native cores. Requires React Native 0.76+
+</Card>
+
+<Card title="Flutter" icon="layer-group" href="/developer-resources/sdks/flutter">
+  Pigeon channel over both native cores. Requires Flutter 3.44+
+</Card>
+</CardGroup>
 
 <Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
-  Install steps and usage for the Swift, Kotlin, and React Native checkout SDKs
+  The end-to-end mobile payment flow, from backend checkout session to callback scheme setup
 </Card>
 
 ## Command-Line Interface

--- a/developer-resources/dodo-payments-sdks.mdx
+++ b/developer-resources/dodo-payments-sdks.mdx
@@ -158,7 +158,8 @@ Get started with any SDK in minutes:
 
 ## Key Features
 
-All SDKs share these core capabilities:
+All **backend** SDKs share these core capabilities. The mobile checkout SDKs
+below are deliberately narrower — they hold no API key and never call the API:
 
 - **Type Safety**: Strong typing for compile-time safety and better IDE support
 - **Error Handling**: Comprehensive exception handling with detailed error messages

--- a/developer-resources/integration-guide.mdx
+++ b/developer-resources/integration-guide.mdx
@@ -38,6 +38,14 @@ Choose the integration path that fits your use case:
 - **Inline Checkout**: Embed checkout directly into your page layout for fully integrated, branded checkout experiences.
 - **Static Payment Links**: No-code, instantly shareable URLs for quick payment collection.
 - **Dynamic Payment Links**: Programmatically created links. However, Checkout Sessions are recommended and provide more flexibility.
+- **[Mobile Checkout SDKs](/developer-resources/mobile-integration)**: For native Android, iOS, React Native, and Flutter apps. Create the session on your server as above, then hand the `checkout_url` to the SDK.
+
+<Info>
+Overlay and Inline Checkout are browser-only — they embed checkout into a web
+page. If you're building a native mobile app, create the checkout session on
+your server and open it with the
+[Mobile Checkout SDKs](/developer-resources/mobile-integration) instead.
+</Info>
 
 #### 1. Checkout Sessions
 

--- a/developer-resources/mobile-integration.mdx
+++ b/developer-resources/mobile-integration.mdx
@@ -10,7 +10,7 @@ keywords: ["Dodo Payments", "developer guide", "mobile payments", "Android", "iO
   Get your mobile payment integration running in 4 simple steps
 </Card>
 
-<Card title="Platform Examples" icon="code" href="#platform-specific-integration">
+<Card title="Platform Examples" icon="code" href="#choose-your-sdk">
   Complete code examples for Android, iOS, React Native, and Flutter
 </Card>
 </CardGroup>
@@ -165,12 +165,8 @@ Open the checkout URL in a secure in-app browser for payment processing.
 Or skip the manual setup entirely with the official checkout SDK for your
 platform.
 
-<Card 
-  title="See platform-specific integration examples" 
-  icon="box" 
-  href="#platform-specific-integration"
->
-  View full code and setup instructions for Android, iOS, React Native, and Flutter mobile payments.
+<Card title="Pick your mobile SDK" icon="box" href="#choose-your-sdk">
+  Install steps and setup instructions for Android, iOS, React Native, and Flutter.
 </Card>
 
 </Step>
@@ -180,7 +176,7 @@ Process payment completion via webhooks and redirect URLs to confirm payment sta
 </Step>
 </Steps>
 
-## Platform-Specific Integration
+## Choose Your SDK
 
 Every mobile SDK exposes the same contract: one `start(...)` call opens Dodo's
 hosted checkout in the platform's native browser surface and returns a typed
@@ -250,6 +246,10 @@ On iOS you must also forward incoming URLs into the SDK, because
 handler.
 </Tab>
 <Tab title="Expo">
+```sh
+npx expo install expo-build-properties
+```
+
 ```json app.json
 {
   "expo": {
@@ -267,6 +267,13 @@ handler.
   }
 }
 ```
+
+<Warning>
+`@dodopayments/react-native-checkout` also ships an Expo config plugin, but it
+currently writes no URL scheme and no manifest placeholder. Adding it alone
+will **not** register your callback scheme — use the configuration above. See
+the [React Native SDK](/developer-resources/sdks/react-native) page.
+</Warning>
 
 Works with development builds only, not Expo Go. Run
 `npx expo prebuild --clean` after editing `app.json`.

--- a/developer-resources/mobile-integration.mdx
+++ b/developer-resources/mobile-integration.mdx
@@ -16,12 +16,11 @@ keywords: ["Dodo Payments", "developer guide", "mobile payments", "Android", "iO
 </CardGroup>
 
 <Info>
-Dodo Payments ships an official checkout SDK for iOS, Android, and React
-Native, with Flutter coming soon. Each one wraps the pattern documented
-below (open the checkout URL, capture the return, parse the result) behind
-a single typed `start(...)` call, with abandoned-session recovery built in.
-Flutter's tab below still shows the manual WebView approach until its SDK
-ships.
+Dodo Payments ships an official checkout SDK for **Android, iOS, React Native,
+and Flutter**. Each one wraps the pattern documented below (open the checkout
+URL, capture the return, parse the result) behind a single typed `start(...)`
+call, with abandoned-session recovery built in. Reach for a manual WebView only
+if none of them fits your stack.
 </Info>
 
 ## Prerequisites
@@ -125,6 +124,36 @@ const getCheckoutURL = async (productId, customerEmail, customerName) => {
 };
 ```
 </Tab>
+<Tab title="Flutter (Dart)">
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<String> getCheckoutUrl({
+  required String productId,
+  required String customerEmail,
+  required String customerName,
+}) async {
+  final response = await http.post(
+    Uri.parse('https://your-backend.com/api/create-checkout-session'),
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $userSessionToken',
+    },
+    body: jsonEncode({
+      'productId': productId,
+      'customerEmail': customerEmail,
+      'customerName': customerName,
+    }),
+  );
+
+  if (response.statusCode != 200) {
+    throw Exception('Failed to get checkout URL: ${response.statusCode}');
+  }
+  return jsonDecode(response.body)['checkout_url'] as String;
+}
+```
+</Tab>
 </Tabs>
 <Note>
 **Security**: Mobile apps only communicate with your backend, never directly with Dodo Payments API.
@@ -153,161 +182,41 @@ Process payment completion via webhooks and redirect URLs to confirm payment sta
 
 ## Platform-Specific Integration
 
-Choose your mobile platform below for complete implementation examples:
+Every mobile SDK exposes the same contract: one `start(...)` call opens Dodo's
+hosted checkout in the platform's native browser surface and returns a typed
+`CheckoutResult` whose `status` is `succeeded`, `failed`, `cancelled`,
+`pending`, or `expired`. None of them holds an API key or calls the Dodo
+Payments API, and all four support abandoned-session recovery.
+
+<CardGroup cols={2}>
+<Card title="Android" icon="android" href="/developer-resources/sdks/android">
+  `com.dodopayments.api:checkout-android` opens a Chrome Custom Tab. Requires `minSdk` 23.
+</Card>
+<Card title="iOS" icon="apple" href="/developer-resources/sdks/ios">
+  `dodopayments-mobile-sdk-ios` opens `SFSafariViewController`. Requires iOS 16+.
+</Card>
+<Card title="React Native" icon="react" href="/developer-resources/sdks/react-native">
+  `@dodopayments/react-native-checkout`, a Turbo Module over both native cores. Requires React Native 0.76+.
+</Card>
+<Card title="Flutter" icon="layer-group" href="/developer-resources/sdks/flutter">
+  `dodopayments_checkout`, a Pigeon channel over both native cores. Requires Flutter 3.44+.
+</Card>
+</CardGroup>
+
+<Warning>
+The `status` you get back is a UI hint, not proof of payment. Confirm every
+payment from your backend via the `payment.succeeded` / `subscription.active`
+webhook, or by retrieving the payment with your secret key.
+</Warning>
+
+### Registering a Callback URL Scheme
+
+All four SDKs hand control back to your app through a custom URL scheme that
+you choose, for example `myapp://checkout/return`. Register it once per
+platform:
 
 <Tabs>
 <Tab title="Android">
-
-### Android Integration
-
-Install the Kotlin Mobile SDK (`com.dodopayments.api:checkout-android`), which
-opens the checkout in a Chrome Custom Tab and hands back a typed result —
-no manual `CustomTabsClient` wiring needed.
-
-```kotlin build.gradle.kts
-dependencies {
-    implementation("com.dodopayments.api:checkout-android:1.0.0")
-}
-
-android {
-    defaultConfig {
-        manifestPlaceholders["dodoCallbackScheme"] = "myapp"
-    }
-}
-```
-
-```kotlin
-import com.dodopayments.checkout.CheckoutParams
-import com.dodopayments.checkout.CheckoutStatus
-import com.dodopayments.checkout.DodoCheckout
-
-private val checkoutLauncher =
-    registerForActivityResult(DodoCheckout.contract()) { result ->
-        when (result.status) {
-            CheckoutStatus.SUCCEEDED -> showSuccess(result.paymentId)
-            CheckoutStatus.FAILED -> showFailure()
-            CheckoutStatus.CANCELLED -> dismiss()
-            CheckoutStatus.PENDING -> showPending()
-            CheckoutStatus.EXPIRED -> showExpired()
-        }
-    }
-
-checkoutLauncher.launch(
-    CheckoutParams(
-        checkoutUrl = checkoutUrl, // from your backend's checkout session
-        returnUrl = "myapp://checkout/return"
-    )
-)
-```
-
-`start` throws `CheckoutError` only for misuse or a platform failure —
-`INVALID_CHECKOUT_URL`, `INVALID_RETURN_URL`, `ALREADY_IN_PROGRESS`, or
-`PLATFORM_ERROR`. A cancelled or declined payment is always a result, never
-a thrown error.
-
-If the app is killed mid-checkout, recover the session on next launch:
-
-```kotlin
-DodoCheckout.getAbandonedSession(context)?.let { abandoned ->
-    // reconcile abandoned.sessionId with your backend, then:
-    DodoCheckout.clearAbandonedSession(context)
-}
-```
-
-</Tab>
-<Tab title="iOS">
-
-### iOS Integration
-
-Install the Swift Mobile SDK
-(`https://github.com/dodopayments/dodopayments-mobile-sdk-ios`), which
-opens the checkout in `SFSafariViewController` and hands back a typed result
-— no manual `SFSafariViewControllerDelegate` or deep-link parsing needed.
-
-```swift
-.package(url: "https://github.com/dodopayments/dodopayments-mobile-sdk-ios", from: "1.0.0")
-```
-
-```swift
-import DodoCheckout
-
-let result = try await DodoCheckout.start(
-    checkoutUrl: checkoutUrl,   // from your backend's checkout session
-    returnUrl: URL(string: "myapp://checkout/return")!,
-    onEvent: { event in print(event.name) }  // logging only
-)
-
-switch result.status {
-case .succeeded: showSuccess(result.paymentId)
-case .failed:    showFailure()
-case .cancelled: dismiss()
-case .pending:   showPending()
-case .expired:   showExpired()
-}
-```
-
-`SFSafariViewController` can't catch its own return URL, so forward incoming
-URLs to `DodoCheckout.handleOpenURL(_:)`:
-
-```swift SwiftUI
-.onOpenURL { url in
-    DodoCheckout.handleOpenURL(url)
-}
-```
-
-`start` throws `CheckoutError` only for misuse or a platform failure —
-`INVALID_CHECKOUT_URL`, `INVALID_RETURN_URL`, `ALREADY_IN_PROGRESS`, or
-`PLATFORM_ERROR`. A cancelled or declined payment is always a result, never
-a thrown error.
-
-If the app is killed mid-checkout, recover the session on next launch:
-
-```swift
-if let abandoned = DodoCheckout.getAbandonedSession() {
-    // reconcile abandoned.sessionId with your backend, then:
-    DodoCheckout.clearAbandonedSession()
-}
-```
-
-</Tab>
-<Tab title="React Native">
-### React Native Integration
-
-Install the React Native SDK (`@dodopayments/react-native-checkout`), a
-thin Turbo Module bridge over the same Swift/Kotlin cores — no
-`react-native-inappbrowser-reborn` dependency needed. Requires the New
-Architecture, React Native 0.76+, iOS 16+, and Android `minSdk` 24.
-
-```sh
-npm i @dodopayments/react-native-checkout
-```
-
-```ts
-import { Linking } from 'react-native';
-import { DodoCheckout } from '@dodopayments/react-native-checkout';
-
-Linking.addEventListener('url', ({ url }) => DodoCheckout.handleOpenURL(url));
-
-const result = await DodoCheckout.start({
-  checkoutUrl,                          // from your backend's checkout session
-  returnUrl: 'myapp://checkout/return', // scheme must be registered (see SDK docs)
-  onEvent: (e) => console.log(e.type),  // logging only
-});
-
-switch (result.status) {
-  case 'succeeded': break;
-  case 'failed':    break;
-  case 'cancelled': break;
-  case 'pending':   break;
-  case 'expired':   break;
-}
-```
-
-Register your callback scheme — a Gradle manifest placeholder on Android,
-a `Info.plist` URL type on iOS:
-
-<Tabs>
-<Tab title="Android (Gradle)">
 ```kotlin android/app/build.gradle
 android {
     defaultConfig {
@@ -315,8 +224,11 @@ android {
     }
 }
 ```
+
+The SDK's own manifest already declares the redirect activity, so there is no
+manifest XML to add.
 </Tab>
-<Tab title="iOS (Info.plist)">
+<Tab title="iOS">
 ```xml Info.plist
 <key>CFBundleURLTypes</key>
 <array>
@@ -330,12 +242,14 @@ android {
   </dict>
 </array>
 ```
-</Tab>
-<Tab title="Expo (both platforms)">
-```sh
-npx expo install expo-build-properties
-```
 
+On iOS you must also forward incoming URLs into the SDK, because
+`SFSafariViewController` cannot catch its own return URL. See the
+[iOS](/developer-resources/sdks/ios) or
+[React Native](/developer-resources/sdks/react-native) page for the exact
+handler.
+</Tab>
+<Tab title="Expo">
 ```json app.json
 {
   "expo": {
@@ -354,139 +268,35 @@ npx expo install expo-build-properties
 }
 ```
 
-Works with development builds only, not Expo Go — rebuild the native
-project (`npx expo prebuild --clean`) after editing `app.json`.
+Works with development builds only, not Expo Go. Run
+`npx expo prebuild --clean` after editing `app.json`.
 </Tab>
 </Tabs>
 
-`start` rejects with a `CheckoutError` only for misuse or a platform
-failure — `INVALID_CHECKOUT_URL`, `INVALID_RETURN_URL`,
-`ALREADY_IN_PROGRESS`, or `PLATFORM_ERROR`. A cancelled or declined payment
-is always a result, never a rejection.
-
-If the app or JS bundle is killed mid-checkout, recover the session on next
-mount:
-
-```ts
-const abandoned = await DodoCheckout.getAbandonedSession();
-if (abandoned) {
-  // reconcile abandoned.sessionId with your backend, then:
-  await DodoCheckout.clearAbandonedSession();
-}
-```
-
-</Tab>
-<Tab title="Flutter">
-
-### Flutter Integration
-
-#### WebView Implementation
-
-```dart
-import 'package:flutter/material.dart';
-import 'package:webview_flutter/webview_flutter.dart';
-import 'package:http/http.dart' as http;
-import 'dart:convert';
-
-Future<String> getCheckoutURL(String productId, String customerEmail, String customerName) async {
-  final response = await http.post(
-    Uri.parse('https://your-backend.com/api/create-checkout-session'),
-    headers: {'Content-Type': 'application/json'},
-    body: json.encode({
-      'productId': productId,
-      'customerEmail': customerEmail,
-      'customerName': customerName,
-    }),
-  );
-  
-  if (response.statusCode == 200) {
-    final data = json.decode(response.body);
-    return data['checkout_url'];
-  } else {
-    throw Exception('Failed to get checkout URL: ${response.statusCode}');
-  }
-}
-class PaymentScreen extends StatefulWidget {
-  @override
-  _PaymentScreenState createState() => _PaymentScreenState();
-}
-class _PaymentScreenState extends State<PaymentScreen> {
-  late WebViewController _controller;
-  String? checkoutURL;
-  
-  @override
-  void initState() {
-    super.initState();
-    _getCheckoutURL();
-  }
-  
-  Future<void> _getCheckoutURL() async {
-    try {
-      final url = await getCheckoutURL('prod_123', 'customer@example.com', 'Customer Name');
-      setState(() {
-        checkoutURL = url;
-      });
-    } catch (e) {
-      // Handle error
-      print('Failed to get checkout URL: $e');
-    }
-  }
-  
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text('Payment')),
-      body: checkoutURL == null 
-        ? Center(child: CircularProgressIndicator())
-        : WebView(
-        initialUrl: checkoutURL,
-        javascriptMode: JavascriptMode.unrestricted,
-        onWebViewCreated: (WebViewController webViewController) {
-          _controller = webViewController;
-        },
-        navigationDelegate: (NavigationRequest request) {
-          if (request.url.contains('payment_id') && request.url.contains('status')) {
-            // Handle payment completion
-            final uri = Uri.parse(request.url);
-            final paymentId = uri.queryParameters['payment_id'];
-            final status = uri.queryParameters['status'];
-            handlePaymentCompletion(paymentId, status);
-            return NavigationDecision.prevent;
-          }
-          return NavigationDecision.navigate;
-        },
-      ),
-    );
-  }
-  void handlePaymentCompletion(String? paymentId, String? status) {
-    if (status == 'succeeded') {
-      // Payment successful
-    } else {
-      // Payment failed
-    }
-  }
-}
-```
-
-<Tip>
-Use WebView for payment links. Handle the redirect URL to detect payment completion.
-</Tip>
-
-</Tab>
-</Tabs>
+<Note>
+Prefer to build it yourself? Open the `checkout_url` in a WebView and intercept
+the navigation to your `return_url`, then read the `status` and `payment_id`
+query parameters. The SDKs above do this for you in the platform's real browser
+surface, which is why Apple Pay and Google Pay keep working.
+</Note>
 
 ## Best Practices
 
-- **Security**: Never store API keys in your app code. Use secure storage and SSL pinning.
-- **User Experience**: Show loading indicators, handle errors gracefully, and provide clear messages.
-- **Testing**: Use test cards, simulate network errors, and test on various devices.
+- **Security**: Never ship an API key in your app. Create checkout sessions on your backend and pass only the resulting `checkout_url` to the client.
+- **Authority**: Treat `CheckoutResult.status` as a UI hint. Grant access only after your backend confirms the payment.
+- **User Experience**: Show a loading state while your backend creates the session, and handle `cancelled` as a normal outcome rather than an error.
+- **Testing**: Use test mode and test cards, and verify the return-URL round trip on a real device as well as a simulator.
 
 ## Troubleshooting
+
 ### Common Issues
 
-- **WebView not opening payment link**: Ensure the payment link is valid and uses HTTPS.
-- **Callback not received**: Check your return URL and webhook configuration.
-- **API key errors**: Verify that your API key is correct and has the necessary permissions.
+- **Callback never arrives**: The scheme in `returnUrl` must match the one you registered. On Android that is the `dodoCallbackScheme` manifest placeholder; on iOS and React Native it is the `Info.plist` URL type.
+- **Checkout returns to the browser instead of your app (iOS)**: You haven't forwarded the incoming URL. Call `DodoCheckout.handleOpenURL(url)` from `.onOpenURL`, `scene(_:openURLContexts:)`, or a React Native `Linking` listener.
+- **`PLATFORM_ERROR` on Android**: Most often a scheme mismatch. It can also appear if your `MainActivity` sets `android:taskAffinity=""` (the stock `flutter create` default), which lets some OEM builds lose the in-flight checkout.
+- **`ALREADY_IN_PROGRESS`**: A checkout is still open. Await or dismiss the previous one before starting another.
+- **Build fails with an unresolved placeholder**: You added the Android SDK but never set `manifestPlaceholders["dodoCallbackScheme"]`.
+- **Payment succeeded but access wasn't granted**: Expected if you're keying off the mobile result. Grant access from the `payment.succeeded` / `subscription.active` webhook instead.
 
 
 ## Additional Resources

--- a/developer-resources/mobile-integration.mdx
+++ b/developer-resources/mobile-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mobile Integration Guide
+sidebarTitle: Integration Guide
 icon: "mobile"
 description: Unified guide for integrating Dodo Payments into Android, iOS, React Native and Flutter mobile applications.
 keywords: ["Dodo Payments", "developer guide", "mobile payments", "Android", "iOS", "Flutter", "mobile integration guide"]

--- a/developer-resources/sdks/android.mdx
+++ b/developer-resources/sdks/android.mdx
@@ -1,0 +1,219 @@
+---
+title: "Android"
+sidebarTitle: "Android"
+tag: "NEW"
+description: "Open Dodo Payments' hosted checkout from an Android app in a Chrome Custom Tab and get a typed result back in one call."
+icon: "android"
+keywords: ["Dodo Payments", "Android SDK", "Kotlin", "mobile checkout SDK", "Custom Tabs"]
+---
+
+<Info>
+This is the official Android checkout SDK (`com.dodopayments.api:checkout-android`),
+for opening Dodo's hosted checkout. It is distinct from the
+[backend Kotlin SDK](/developer-resources/sdks/kotlin), which calls the Dodo
+Payments API from your server.
+</Info>
+
+<CardGroup cols={2}>
+  <Card title="Checkout Sessions API" icon="cart-shopping" href="/developer-resources/checkout-session">
+    Create the `checkout_url` that this SDK opens
+  </Card>
+  <Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+    Best practices for mobile checkout flows
+  </Card>
+</CardGroup>
+
+The Android SDK opens Dodo's hosted checkout in a Chrome Custom Tab using `androidx.browser.customtabs`. It contains zero networking code and holds no API key. You pass a `checkoutUrl` from your backend's checkout session, and the SDK returns a typed `CheckoutResult` when the user completes or abandons the flow.
+
+**Requirements:** `minSdk` 23, Kotlin, Java 17.
+
+## Installation
+
+<Steps>
+<Step title="Add the Dependency">
+```kotlin build.gradle.kts
+dependencies {
+    implementation("com.dodopayments.api:checkout-android:1.0.0")
+}
+```
+</Step>
+<Step title="Register a Callback URL Scheme">
+Set your callback scheme as a Gradle manifest placeholder. The library's own
+manifest already declares the redirect activity's intent filter using the
+`${dodoCallbackScheme}` token, so this one property is the entire setup cost —
+you add no manifest XML:
+
+```kotlin build.gradle.kts
+android {
+    defaultConfig {
+        manifestPlaceholders["dodoCallbackScheme"] = "myapp"
+    }
+}
+```
+
+The value must match the scheme in `CheckoutParams.returnUrl` (e.g.
+`myapp://checkout/return`).
+
+<Note>
+If you omit the placeholder entirely, the build fails immediately with an
+unresolved-placeholder error rather than failing silently at checkout time. If
+you set it but it doesn't match `returnUrl`'s scheme, `DodoCheckout.start`
+throws `PLATFORM_ERROR` before presenting anything.
+</Note>
+</Step>
+</Steps>
+
+## Usage
+
+The SDK supports two invocation styles.
+
+<Tabs>
+<Tab title="Launcher (Recommended)">
+Register the contract with `registerForActivityResult`, then launch it:
+
+```kotlin
+import com.dodopayments.checkout.CheckoutParams
+import com.dodopayments.checkout.CheckoutStatus
+import com.dodopayments.checkout.DodoCheckout
+
+private val checkoutLauncher =
+    registerForActivityResult(DodoCheckout.contract()) { result ->
+        when (result.status) {
+            CheckoutStatus.SUCCEEDED -> showSuccess(result.paymentId)
+            CheckoutStatus.FAILED -> showFailure()
+            CheckoutStatus.CANCELLED -> dismiss()
+            CheckoutStatus.PENDING -> showPending()
+            CheckoutStatus.EXPIRED -> showExpired()
+        }
+    }
+
+checkoutLauncher.launch(
+    CheckoutParams(
+        checkoutUrl = checkoutUrl, // from your backend's checkout session
+        returnUrl = "myapp://checkout/return"
+    )
+)
+```
+
+<Tip>
+Prefer this style. The result is delivered through Android's OS-managed
+`ActivityResultRegistry`, so it survives process death.
+</Tip>
+</Tab>
+<Tab title="Suspend Function">
+Call `DodoCheckout.start` from a coroutine scope:
+
+```kotlin
+import com.dodopayments.checkout.CheckoutParams
+import com.dodopayments.checkout.CheckoutStatus
+import com.dodopayments.checkout.DodoCheckout
+
+lifecycleScope.launch {
+    val result = DodoCheckout.start(
+        activity = this@MyActivity,
+        params = CheckoutParams(
+            checkoutUrl = checkoutUrl, // from your backend's checkout session
+            returnUrl = "myapp://checkout/return"
+        ),
+        onEvent = { event -> println(event.name) } // logging only
+    )
+
+    when (result.status) {
+        CheckoutStatus.SUCCEEDED -> showSuccess(result.paymentId)
+        CheckoutStatus.FAILED -> showFailure()
+        CheckoutStatus.CANCELLED -> dismiss()
+        CheckoutStatus.PENDING -> showPending()
+        CheckoutStatus.EXPIRED -> showExpired()
+    }
+}
+```
+
+<Warning>
+This style resolves an in-memory `CompletableDeferred`, so it does **not**
+survive process death. `onEvent` is available only here, not on the contract.
+</Warning>
+</Tab>
+</Tabs>
+
+## What the Result Means
+
+<Warning>
+The `status` field is a UI hint, not proof of payment. Always verify the payment on your backend using webhooks or the Get Payment Detail endpoint before granting access.
+</Warning>
+
+<ParamField body="status" type="CheckoutStatus" required>
+One of `SUCCEEDED`, `FAILED`, `CANCELLED`, `PENDING`, `EXPIRED`.
+</ParamField>
+
+<ParamField body="paymentId" type="String?">
+Set when the return URL included one. Display it in the UI, don't use it to
+grant access. See Verify the Payment below.
+</ParamField>
+
+<ParamField body="subscriptionId" type="String?">
+Set for subscription checkouts.
+</ParamField>
+
+<ParamField body="licenseKeys" type="List<String>?">
+Set when the checkout includes license key products.
+</ParamField>
+
+<ParamField body="customerEmail" type="String?">
+Set when the checkout captures an email.
+</ParamField>
+
+<ParamField body="raw" type="Map<String, String>">
+Every query parameter from the return URL, verbatim.
+</ParamField>
+
+## Verify the Payment
+
+<CardGroup cols={2}>
+  <Card title="Webhooks" icon="webhook" href="/developer-resources/webhooks">
+    Listen for payment events in real time
+  </Card>
+  <Card title="Get Payment Detail" icon="magnifying-glass" href="/api-reference/payments/get-payments-1">
+    Query the payment status on demand
+  </Card>
+</CardGroup>
+
+Grant access to the user only after one of these confirms the payment. Do not rely on the `CheckoutResult.status` alone.
+
+## Errors
+
+`DodoCheckout.start` throws `CheckoutError` only for misuse or a platform
+failure. Read the code from `CheckoutError.code`:
+
+- `INVALID_CHECKOUT_URL`: not a `checkout.dodopayments.com` session URL.
+- `INVALID_RETURN_URL`: not a valid absolute URL.
+- `ALREADY_IN_PROGRESS`: a checkout is already running.
+- `PLATFORM_ERROR`: unexpected platform failure, including a `returnUrl` whose
+  scheme doesn't match your `dodoCallbackScheme` placeholder.
+
+A user cancelling or a declined payment is always a result (`CANCELLED` or
+`FAILED`), never a thrown error. With the launcher style, validation errors
+throw out of `launcher.launch(...)`.
+
+## Abandoned Sessions
+
+If the app is killed or the user force-stops it during checkout, the SDK stores the session locally. On the next app launch, check for an abandoned session and reconcile it with your backend:
+
+```kotlin
+DodoCheckout.getAbandonedSession(context)?.let { abandoned ->
+    // reconcile abandoned.sessionId with your backend, then:
+    DodoCheckout.clearAbandonedSession(context)
+}
+```
+
+The `abandoned.createdAt` is an epoch timestamp in milliseconds.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+    Best practices for mobile checkout flows
+  </Card>
+  <Card title="Kotlin SDK" icon="code" href="/developer-resources/sdks/kotlin">
+    Backend SDK for server-side operations
+  </Card>
+</CardGroup>

--- a/developer-resources/sdks/flutter.mdx
+++ b/developer-resources/sdks/flutter.mdx
@@ -35,17 +35,34 @@ Requires Flutter 3.44+ / Dart 3.12+, iOS 16+, and Android `minSdk` 23.
 ## Installation
 
 <Steps>
-<Step title="Add the dependency">
+<Step title="Add the Dependency">
 ```yaml pubspec.yaml
 dependencies:
   dodopayments_checkout: ^1.0.0
 ```
 </Step>
-<Step title="Register a callback URL scheme">
+<Step title="Register a Callback URL Scheme">
 <Tabs>
 <Tab title="iOS">
-Add a URL type for your scheme in `Info.plist`, then forward incoming URLs
-(e.g. via [`app_links`](https://pub.dev/packages/app_links)) into the SDK:
+Add a URL type for your scheme in `ios/Runner/Info.plist`:
+
+```xml ios/Runner/Info.plist
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>myapp</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+Then forward incoming URLs (e.g. via
+[`app_links`](https://pub.dev/packages/app_links)) into the SDK, because
+`SFSafariViewController` cannot catch its own return URL:
 
 ```dart
 import 'package:dodopayments_checkout/dodopayments_checkout.dart';
@@ -118,6 +135,18 @@ One of `succeeded`, `failed`, `cancelled`, `pending`, `expired`.
 <ParamField body="paymentId" type="String?">
 Set when the return URL included one. Display it in the UI, don't use it
 to grant access. See Verify the Payment below.
+</ParamField>
+
+<ParamField body="subscriptionId" type="String?">
+Set for subscription checkouts.
+</ParamField>
+
+<ParamField body="licenseKeys" type="List<String>?">
+Set when the checkout includes license key products.
+</ParamField>
+
+<ParamField body="customerEmail" type="String?">
+Set when the checkout captures an email.
 </ParamField>
 
 <ParamField body="raw" type="Map<String, String>">

--- a/developer-resources/sdks/flutter.mdx
+++ b/developer-resources/sdks/flutter.mdx
@@ -1,9 +1,10 @@
 ---
-title: "Flutter Checkout SDK"
+title: "Flutter"
+sidebarTitle: "Flutter"
 tag: "NEW"
 description: "Open Dodo Payments' hosted checkout from Flutter in a system browser tab and get a typed result back in one call."
 icon: "layer-group"
-keywords: ["Dodo Payments", "developer guide", "Flutter", "Dart", "mobile checkout SDK"]
+keywords: ["Dodo Payments", "Flutter SDK", "Dart", "mobile checkout SDK", "pub.dev"]
 ---
 
 <Info>
@@ -22,11 +23,12 @@ on pub.dev). A separate, community-built package also exists, see
 </CardGroup>
 
 `dodopayments_checkout` opens Dodo's hosted checkout in
-`SFSafariViewController` on iOS and a Chrome Custom Tab on Android, the same
-native cores as the standalone iOS and Android SDKs (see the
-[Mobile Integration Guide](/developer-resources/mobile-integration)). All
-checkout logic lives in those native cores; the Dart layer passes the call
-through a typed [Pigeon](https://pub.dev/packages/pigeon) channel.
+`SFSafariViewController` on iOS and a Chrome Custom Tab on Android — the same
+native cores used by the standalone [iOS](/developer-resources/sdks/ios) and
+[Android](/developer-resources/sdks/android) SDKs. All checkout logic lives in
+those native cores; the Dart layer passes the call through a typed
+[Pigeon](https://pub.dev/packages/pigeon) channel. It holds no API key and
+never calls the Dodo Payments API.
 
 Requires Flutter 3.44+ / Dart 3.12+, iOS 16+, and Android `minSdk` 23.
 
@@ -165,6 +167,11 @@ if (abandoned != null) {
 
 ## Related
 
+<CardGroup cols={2}>
 <Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
-  The same contract for Swift, Kotlin, and React Native.
+  The same contract for Android, iOS, and React Native.
 </Card>
+<Card title="Community Projects" icon="users" href="/community/projects">
+  A separate, community-built Flutter package also exists.
+</Card>
+</CardGroup>

--- a/developer-resources/sdks/ios.mdx
+++ b/developer-resources/sdks/ios.mdx
@@ -1,0 +1,188 @@
+---
+title: "iOS"
+sidebarTitle: "iOS"
+tag: "NEW"
+description: "Open Dodo Payments' hosted checkout from an iOS app in SFSafariViewController and get a typed result back in one call."
+icon: "apple"
+keywords: ["Dodo Payments", "iOS SDK", "Swift", "mobile checkout SDK", "SFSafariViewController"]
+---
+
+<Info>
+This is the official Dodo Payments iOS checkout SDK for Swift. It opens Dodo's hosted checkout in a native browser view and returns a typed result.
+</Info>
+
+<CardGroup cols={2}>
+<Card title="Checkout Sessions API" icon="cart-shopping" href="/developer-resources/checkout-session">
+  Create the checkout_url this SDK opens, from your backend.
+</Card>
+<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+  See how this fits into the full mobile payment flow.
+</Card>
+</CardGroup>
+
+The iOS SDK opens Dodo's hosted checkout in `SFSafariViewController`, holds no API key, and never calls the Dodo API directly. All checkout logic runs in the browser; the SDK simply manages the view lifecycle and captures the return URL.
+
+Requires iOS 16+, Swift 6.
+
+## Installation
+
+<Steps>
+<Step title="Add the Package">
+In Xcode, go to **File → Add Package Dependencies** and enter:
+
+```
+https://github.com/dodopayments/dodopayments-mobile-sdk-ios
+```
+
+Select version 1.0.0 or later.
+
+Alternatively, add to your `Package.swift`:
+
+```swift Package.swift
+.package(url: "https://github.com/dodopayments/dodopayments-mobile-sdk-ios", from: "1.0.0")
+```
+</Step>
+<Step title="Register a Callback URL Scheme">
+Your app must register a URL scheme to receive the return URL from the checkout. Add this to your `Info.plist`:
+
+```xml Info.plist
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>myapp</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+You can also add this via Xcode's **Info → URL Types** UI.
+</Step>
+</Steps>
+
+## Usage
+
+```swift
+import DodoCheckout
+
+let result = try await DodoCheckout.start(
+    checkoutUrl: checkoutUrl,   // from your backend's checkout session
+    returnUrl: URL(string: "myapp://checkout/return")!,
+    onEvent: { event in print(event.name) }  // logging only
+)
+
+switch result.status {
+case .succeeded: showSuccess(result.paymentId)
+case .failed:    showFailure()
+case .cancelled: dismiss()
+case .pending:   showPending()
+case .expired:   showExpired()
+}
+```
+
+## Forwarding the Return URL
+
+`SFSafariViewController` has no in-process way to catch its own return URL. Your app must forward incoming URLs into the SDK.
+
+<Tabs>
+<Tab title="SwiftUI">
+```swift
+.onOpenURL { url in
+    DodoCheckout.handleOpenURL(url)
+}
+```
+</Tab>
+<Tab title="SceneDelegate">
+```swift SceneDelegate.swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let url = URLContexts.first?.url else { return }
+    DodoCheckout.handleOpenURL(url)
+}
+```
+</Tab>
+</Tabs>
+
+<Note>
+It's safe to forward every URL here. `handleOpenURL` only acts on URLs matching your registered `returnUrl` and returns `false` for anything else.
+</Note>
+
+## What the Result Means
+
+<Warning>
+`result.status` is a UI hint, not proof of payment. Confirm every payment from your backend, via the `payment.succeeded` / `subscription.active` webhook.
+</Warning>
+
+<ParamField body="status" type="CheckoutStatus" required>
+One of `succeeded`, `failed`, `cancelled`, `pending`, `expired`.
+</ParamField>
+
+<ParamField body="paymentId" type="String?">
+Set when the return URL included one. Display it in the UI, don't use it to grant access. See Verify the Payment below.
+</ParamField>
+
+<ParamField body="subscriptionId" type="String?">
+Set for subscription checkouts.
+</ParamField>
+
+<ParamField body="licenseKeys" type="[String]?">
+Set when the checkout includes license key products.
+</ParamField>
+
+<ParamField body="customerEmail" type="String?">
+Set when the checkout captures an email.
+</ParamField>
+
+<ParamField body="raw" type="[String: String]">
+Every query parameter from the return URL, verbatim.
+</ParamField>
+
+## Verify the Payment
+
+<CardGroup cols={2}>
+<Card title="Webhooks" icon="webhook" href="/developer-resources/webhooks">
+  Dodo Payments calls your backend when a payment succeeds or a subscription activates.
+</Card>
+<Card title="Get Payment Detail" icon="magnifying-glass" href="/api-reference/payments/get-payments-1">
+  Look up `paymentId` with your secret key to check its status directly.
+</Card>
+</CardGroup>
+
+Grant access after one of these confirms the payment, never from `result.status` alone.
+
+## Errors
+
+`start` throws `CheckoutError` only for misuse or a platform failure. A cancelled or declined payment is always a result, never an exception.
+
+- `invalidCheckoutUrl` (`INVALID_CHECKOUT_URL`): not a `checkout.dodopayments.com` session URL.
+- `invalidReturnUrl` (`INVALID_RETURN_URL`): not a valid absolute URL.
+- `alreadyInProgress` (`ALREADY_IN_PROGRESS`): a checkout is already running.
+- `platformError` (`PLATFORM_ERROR`): unexpected platform failure.
+
+## Abandoned Sessions
+
+<Info>
+If the app is killed mid-checkout, recover the session on next launch and reconcile it with your backend.
+</Info>
+
+```swift
+import DodoCheckout
+
+if let abandoned = DodoCheckout.getAbandonedSession() {
+    // reconcile abandoned.sessionId with your backend, then:
+    DodoCheckout.clearAbandonedSession()
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+  The same contract for Android, React Native, and Flutter.
+</Card>
+<Card title="React Native SDK" icon="react" href="/developer-resources/sdks/react-native">
+  Wraps this same Swift core on iOS.
+</Card>
+</CardGroup>

--- a/developer-resources/sdks/react-native.mdx
+++ b/developer-resources/sdks/react-native.mdx
@@ -1,0 +1,263 @@
+---
+title: "React Native"
+sidebarTitle: "React Native"
+tag: "NEW"
+description: "Open Dodo Payments' hosted checkout from a React Native app in a system browser tab and get a typed result back in one call."
+icon: "react"
+keywords: ["Dodo Payments", "React Native SDK", "Expo", "mobile checkout SDK", "Turbo Module"]
+---
+
+<Info>
+This is the official Dodo Payments React Native checkout SDK, `@dodopayments/react-native-checkout`. It opens Dodo's hosted checkout in a native browser view and returns a typed result. Note: an older, unrelated package named `dodopayments-react-native-sdk` (unscoped) exists with a completely different API. This page documents the current official scoped package only.
+</Info>
+
+<CardGroup cols={2}>
+<Card title="Checkout Sessions API" icon="cart-shopping" href="/developer-resources/checkout-session">
+  Create the checkout_url this SDK opens, from your backend.
+</Card>
+<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+  See how this fits into the full mobile payment flow.
+</Card>
+</CardGroup>
+
+The React Native SDK is a thin Turbo Module wrapper over the same native Swift and Kotlin cores. It opens `SFSafariViewController` on iOS and a Chrome Custom Tab on Android, holds no API key, and never calls the Dodo API directly. All checkout logic runs in the browser; the SDK simply manages the view lifecycle and captures the return URL.
+
+<Warning>
+This SDK requires **New Architecture only**, React Native 0.76+, iOS 16+, and Android `minSdk` 24.
+</Warning>
+
+## Installation
+
+<Steps>
+<Step title="Install the Package">
+<Tabs>
+<Tab title="Android">
+The package is autolinked and pulls `com.dodopayments.api:checkout-android` from Maven.
+
+```sh
+npm i @dodopayments/react-native-checkout
+```
+
+No additional setup needed; the native dependency is resolved automatically.
+</Tab>
+<Tab title="iOS">
+```sh
+npm i @dodopayments/react-native-checkout
+cd ios && pod install
+```
+
+The Swift core is bundled in the package and installed via CocoaPods.
+</Tab>
+<Tab title="Expo">
+Development builds only (not Expo Go).
+
+```sh
+npm i @dodopayments/react-native-checkout
+npx expo install expo-build-properties
+```
+
+Then configure your `app.json` (see Register a Callback URL Scheme below).
+</Tab>
+</Tabs>
+</Step>
+<Step title="Register a Callback URL Scheme">
+Your app must register a URL scheme to receive the return URL from the checkout.
+
+<Tabs>
+<Tab title="Android (Gradle)">
+In `android/app/build.gradle`:
+
+```kotlin android/app/build.gradle
+android {
+    defaultConfig {
+        manifestPlaceholders["dodoCallbackScheme"] = "myapp"
+    }
+}
+```
+
+Replace `"myapp"` with your app's scheme.
+</Tab>
+<Tab title="iOS (Info.plist)">
+In `ios/YourApp/Info.plist`:
+
+```xml Info.plist
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>myapp</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+You can also add this via Xcode's **Info → URL Types** UI.
+</Tab>
+<Tab title="Expo (both platforms)">
+In `app.json`:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "manifestPlaceholders": {
+              "dodoCallbackScheme": "myapp"
+            }
+          }
+        }
+      ]
+    ],
+    "ios": {
+      "infoPlist": {
+        "CFBundleURLTypes": [
+          {
+            "CFBundleURLSchemes": ["myapp"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+<Warning>
+The package also ships an `@dodopayments/react-native-checkout` Expo config
+plugin, but it currently writes no URL scheme and no manifest placeholder.
+Adding it alone will **not** register your callback scheme — use the
+`expo-build-properties` and `infoPlist` configuration above.
+</Warning>
+
+<Note>
+Rebuild the native project after editing `app.json`:
+
+```sh
+npx expo prebuild --clean
+```
+
+This works with development builds only, not Expo Go.
+</Note>
+</Tab>
+</Tabs>
+</Step>
+</Steps>
+
+## Usage
+
+```typescript
+import { Linking } from 'react-native';
+import { DodoCheckout } from '@dodopayments/react-native-checkout';
+
+// Required for iOS's return-URL handling.
+Linking.addEventListener('url', ({ url }) => DodoCheckout.handleOpenURL(url));
+
+const result = await DodoCheckout.start({
+  checkoutUrl,                          // from your backend's checkout session
+  returnUrl: 'myapp://checkout/return', // scheme must be registered (see Installation)
+  onEvent: (e) => console.log(e.type),  // logging only
+});
+
+switch (result.status) {
+  case 'succeeded': showSuccess(result.paymentId); break;
+  case 'failed':    showFailure(); break;
+  case 'cancelled': dismiss(); break;
+  case 'pending':   showPending(); break;
+  case 'expired':   showExpired(); break;
+}
+```
+
+## Forwarding the Return URL
+
+The `Linking` listener is required for iOS's return-URL handling. On Android, `handleOpenURL` is a no-op that resolves `false` because the Android core handles its redirect natively. It's safe to register the listener unconditionally on both platforms.
+
+```typescript
+import { Linking } from 'react-native';
+import { DodoCheckout } from '@dodopayments/react-native-checkout';
+
+Linking.addEventListener('url', ({ url }) => {
+  DodoCheckout.handleOpenURL(url);
+});
+```
+
+## What the Result Means
+
+<Warning>
+`result.status` is a UI hint, not proof of payment. Confirm every payment from your backend, via the `payment.succeeded` / `subscription.active` webhook.
+</Warning>
+
+<ParamField body="status" type="CheckoutStatus" required>
+One of `succeeded`, `failed`, `cancelled`, `pending`, `expired`.
+</ParamField>
+
+<ParamField body="paymentId" type="string">
+Set when the return URL included one. Display it in the UI, don't use it to grant access. See Verify the Payment below.
+</ParamField>
+
+<ParamField body="subscriptionId" type="string">
+Set for subscription checkouts.
+</ParamField>
+
+<ParamField body="licenseKeys" type="string[]">
+Set when the checkout includes license key products.
+</ParamField>
+
+<ParamField body="customerEmail" type="string">
+Set when the checkout captures an email.
+</ParamField>
+
+<ParamField body="raw" type="Record<string, string>">
+Every query parameter from the return URL, verbatim.
+</ParamField>
+
+## Verify the Payment
+
+<CardGroup cols={2}>
+<Card title="Webhooks" icon="webhook" href="/developer-resources/webhooks">
+  Dodo Payments calls your backend when a payment succeeds or a subscription activates.
+</Card>
+<Card title="Get Payment Detail" icon="magnifying-glass" href="/api-reference/payments/get-payments-1">
+  Look up `paymentId` with your secret key to check its status directly.
+</Card>
+</CardGroup>
+
+Grant access after one of these confirms the payment, never from `result.status` alone.
+
+## Errors
+
+`start` rejects with a `CheckoutError` only for misuse or a platform failure. A cancelled or declined payment is always a result, never an exception.
+
+- `INVALID_CHECKOUT_URL`: not a `checkout.dodopayments.com` session URL.
+- `INVALID_RETURN_URL`: not a valid absolute URL.
+- `ALREADY_IN_PROGRESS`: a checkout is already running.
+- `PLATFORM_ERROR`: unexpected platform failure.
+
+## Abandoned Sessions
+
+If the app or the JS bundle is killed mid-checkout, the promise is lost but the native layer keeps the session. Recover it on next mount and reconcile it with your backend.
+
+```typescript
+import { DodoCheckout } from '@dodopayments/react-native-checkout';
+
+const abandoned = await DodoCheckout.getAbandonedSession();
+if (abandoned) {
+  // reconcile abandoned.sessionId with your backend, then:
+  await DodoCheckout.clearAbandonedSession();
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+  The same contract for Android, iOS, and Flutter.
+</Card>
+<Card title="Expo Boilerplate" icon="layer-group" href="/developer-resources/expo-boilerplate">
+  A complete Expo example with checkout integration.
+</Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -12234,7 +12234,7 @@
     },
     {
       "source": "/api-reference/react-native-integration",
-      "destination": "/developer-resources/react-native-integration"
+      "destination": "/developer-resources/sdks/react-native"
     },
     {
       "source": "/api-reference/mcp-server",

--- a/docs.json
+++ b/docs.json
@@ -222,7 +222,17 @@
                       "developer-resources/sdks/rust"
                     ]
                   },
-                  "developer-resources/mobile-integration",
+                  {
+                    "group": "Mobile Checkout SDKs",
+                    "icon": "mobile",
+                    "pages": [
+                      "developer-resources/mobile-integration",
+                      "developer-resources/sdks/android",
+                      "developer-resources/sdks/ios",
+                      "developer-resources/sdks/react-native",
+                      "developer-resources/sdks/flutter"
+                    ]
+                  },
                   {
                     "group": "Framework Adaptors",
                     "icon": "frame",
@@ -12236,15 +12246,15 @@
     },
     {
       "source": "/api-reference/mobile-integration-android",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/android"
     },
     {
       "source": "/api-reference/mobile-integration-ios",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/ios"
     },
     {
       "source": "/api-reference/mobile-integration-flutter",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/flutter"
     },
     {
       "source": "/features/woocommerce-plugin",
@@ -12312,27 +12322,35 @@
     },
     {
       "source": "/developer-resources/mobile-integration-android",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/android"
     },
     {
       "source": "/developer-resources/mobile-integration-ios",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/ios"
     },
     {
       "source": "/developer-resources/mobile-integration-flutter",
-      "destination": "/developer-resources/mobile-integration"
+      "destination": "/developer-resources/sdks/flutter"
     },
     {
       "source": "/developer-resources/ios-checkout-sdk",
-      "destination": "/developer-resources/mobile-integration#ios-integration"
+      "destination": "/developer-resources/sdks/ios"
     },
     {
       "source": "/developer-resources/android-checkout-sdk",
-      "destination": "/developer-resources/mobile-integration#android-integration"
+      "destination": "/developer-resources/sdks/android"
     },
     {
       "source": "/developer-resources/react-native-checkout-sdk",
-      "destination": "/developer-resources/mobile-integration#react-native-integration"
+      "destination": "/developer-resources/sdks/react-native"
+    },
+    {
+      "source": "/developer-resources/react-native-integration",
+      "destination": "/developer-resources/sdks/react-native"
+    },
+    {
+      "source": "/developer-resources/flutter-checkout-sdk",
+      "destination": "/developer-resources/sdks/flutter"
     },
     {
       "source": "/features/gtm-tools/saas-pricing-calculator",

--- a/features/appstore-digital-goods.mdx
+++ b/features/appstore-digital-goods.mdx
@@ -62,44 +62,71 @@ Dodo Payments serves as your **Merchant of Record (MoR)**, managing critical asp
 
 ## Integration Flow
 
-You can integrate Dodo Payments into your app using our hosted checkout or in-app browser solution.
+Your app opens Dodo's hosted checkout with the
+[iOS checkout SDK](/developer-resources/sdks/ios), which presents it in
+`SFSafariViewController` and hands back a typed result.
+
+<Warning>
+Use the SDK rather than embedding checkout in a `WebView`. Apple Pay is only
+available in a real browser surface, so a `WebView` silently costs you wallet
+conversions — and payment flows inside a `WebView` are a common cause of App
+Store review rejections.
+</Warning>
 
 ```mermaid
 flowchart LR
-  A[Mobile App] -->|Create Payment Link| B(Dodo API)
-  B -->|Checkout URL| A
-  A -->|Open in WebView| C[Checkout Page]
-  C -->|Redirects / Webhooks| D[Your Server]
-  D -->|Grant Access| A
+  A[Mobile App] -->|Request checkout| B(Your Server)
+  B -->|Create checkout session| C(Dodo API)
+  C -->|checkout_url| B
+  B -->|checkout_url| A
+  A -->|SDK opens SFSafariViewController| D[Hosted Checkout]
+  D -->|Webhook| B
+  B -->|Grant access| A
 ```
 
 ### Integration Steps
 
 <Steps>
-<Step title="Mobile App to Dodo API">
-The process begins with the mobile app creating a payment link by interacting with the Dodo API.
+<Step title="Mobile App to Your Server">
+Your app asks your own backend for a checkout URL, authenticated with the
+signed-in user's session token.
 </Step>
 
-<Step title="Dodo API to Mobile App">
-The Dodo API responds by providing a checkout URL back to the mobile app.
+<Step title="Your Server to Dodo API">
+Your backend creates a [checkout session](/developer-resources/checkout-session)
+with your API key and returns the `checkout_url` to the app.
+
+<Warning>
+Create checkout sessions on your server, never in the app. An API key shipped
+inside an app binary can be extracted from the bundle.
+</Warning>
 </Step>
 
-<Step title="Mobile App to Checkout Page">
-The mobile app then opens this checkout URL within a WebView, leading the user to the checkout page.
+<Step title="Mobile App Opens Checkout">
+Pass the `checkout_url` to `DodoCheckout.start(...)`. The SDK presents it in
+`SFSafariViewController` and resolves with a typed result when the customer
+completes or dismisses checkout.
 </Step>
 
-<Step title="Checkout Page to Your Server">
-Upon completion of the checkout process, the checkout page communicates with your server through redirects or webhooks.
+<Step title="Dodo Payments to Your Server">
+Dodo Payments calls your webhook endpoint when the payment succeeds or the
+subscription activates.
 </Step>
 
-<Step title="Your Server to Mobile App">
-Finally, your server grants access to the purchased content or service, completing the transaction cycle back in the mobile app.
+<Step title="Your Server Grants Access">
+Unlock the purchased content from that webhook, not from the result the app
+received. The SDK result is a UI hint, not proof of payment.
 </Step>
 </Steps>
 
-<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
-For a complete developer walkthrough, explore our Mobile Integration Guide.
+<CardGroup cols={2}>
+<Card title="iOS Checkout SDK" icon="apple" href="/developer-resources/sdks/ios">
+  Install steps and the full `start(...)` contract for Swift.
 </Card>
+<Card title="Mobile Integration Guide" icon="mobile" href="/developer-resources/mobile-integration">
+  The end-to-end flow, plus the same contract for Android, React Native, and Flutter.
+</Card>
+</CardGroup>
 
 ## Regional Availability
 

--- a/features/payment-methods/digital-wallets.mdx
+++ b/features/payment-methods/digital-wallets.mdx
@@ -239,7 +239,9 @@ All digital wallets are fully supported in:
 
 ### Mobile SDKs (Checkout)
 
-The Swift, Kotlin, and React Native checkout SDKs open Dodo's hosted
+The [Android](/developer-resources/sdks/android), [iOS](/developer-resources/sdks/ios),
+[React Native](/developer-resources/sdks/react-native), and
+[Flutter](/developer-resources/sdks/flutter) checkout SDKs open Dodo's hosted
 checkout in the platform's real browser surface (`SFSafariViewController` /
 Chrome Custom Tabs), not a WebView, so Apple Pay and Google Pay work the
 same way they do on the web. See the [Mobile Integration Guide](/developer-resources/mobile-integration) for setup.


### PR DESCRIPTION
## Summary

Adds standalone documentation pages for all four mobile checkout SDKs (Android, iOS, React Native, Flutter) under `developer-resources/sdks/`, and fixes the Flutter coverage gap.

## The Flutter problem

Three separate issues were making the Flutter SDK effectively invisible:

1. **`developer-resources/flutter-checkout-sdk.mdx` existed on disk but was never registered in `docs.json`** — so it returned a 404 on the live site. `scripts/findMissingPages.ts` flagged it as orphaned.
2. **`mobile-integration.mdx` said "Flutter coming soon"** and documented a manual `webview_flutter` implementation — while `dodopayments_checkout` **1.0.1** is published on pub.dev under the verified `dodopayments.com` publisher.
3. **`dodo-payments-sdks.mdx` listed the mobile SDKs as "Swift, Kotlin, and React Native"**, omitting Flutter — across two duplicated "Mobile Checkout SDKs" sections.

Flutter was also missing from the backend checkout-session step's language tabs.

## Approach

This deliberately does **not** revert the recent consolidation in #446/#447. The unified `mobile-integration.mdx` stays as the umbrella guide; the new pages live at `developer-resources/sdks/*`, alongside the existing backend SDK pages, so none of the existing per-platform redirects are disturbed.

The umbrella guide now links out to the per-SDK pages rather than duplicating their code. That duplication is precisely how the Flutter tab drifted out of date while a shipped SDK went undocumented.

## New pages

| Page | Package |
|---|---|
| `sdks/android.mdx` | `com.dodopayments.api:checkout-android` |
| `sdks/ios.mdx` | `dodopayments-mobile-sdk-ios` |
| `sdks/react-native.mdx` | `@dodopayments/react-native-checkout` |
| `sdks/flutter.mdx` | `dodopayments_checkout` |

Every API signature was read from the `dodopayments-mobile-sdk` sources rather than inferred across platforms, because the four SDKs genuinely diverge:

- **Android** exposes both `suspend start(activity, params, onEvent?)` **and** `contract()` for `registerForActivityResult`. The contract is recommended — it survives process death; the suspend form does not. Status values are `SCREAMING_SNAKE_CASE`, abandoned-session calls require a `Context`, and `handleOpenURL` **does not exist** on Android.
- **iOS** uses a static `enum` namespace, so it is `DodoCheckout.start(...)` with three labeled arguments — there is no `.instance` and no `CheckoutParams` struct. SPM only; there is no podspec.
- **React Native** nests `onEvent` inside the params object and uses lowercase string-literal statuses.

## Also fixed

- **Dead anchor redirects.** `ios-checkout-sdk`, `android-checkout-sdk`, and `react-native-checkout-sdk` pointed at `mobile-integration#ios-integration` style anchors. Those headings no longer exist after this restructure, so they now point at the new per-platform pages.
- **`/developer-resources/react-native-integration` has 404'd since 0c29b6e** removed the page without a redirect. Added one. This was the only broken internal link in English content, and it also resolves the stale copies still present in the translated folders.
- **Troubleshooting rewritten** around real failure modes — callback scheme mismatch, missing `handleOpenURL` forwarding, the `android:taskAffinity=""` OEM issue — instead of "API key errors", which cannot occur in SDKs that hold no API key.
- Documented that the `@dodopayments/react-native-checkout` Expo config plugin is currently a no-op passthrough, so `expo-build-properties` is required to register the callback scheme. Following the plugin alone would leave checkout silently unable to return to the app.

## Verification

- `docs.json` parses as valid JSON
- `node scripts/findMissingPages.ts` — all 4 new pages registered; the 23 remaining orphans are pre-existing and unrelated (`raw-card-api`, localized-prices, entitlements)
- Zero broken internal links in English content (was 1 before this PR)
- JSX component tags balance in all new and edited files

`mintlify broken-links` needs an LTS Node and this machine is on Node 26, so link checking was done with an equivalent script resolving every internal link against the page set and the redirects table.

## Notes for reviewers

- Translated language folders are intentionally untouched — they're regenerated by `scripts/syncAllLanguages.ts`. The new pages will need a sync run to appear in the 13 locales.
- Worth a second opinion on whether `dodopayments_checkout` should carry `tag: NEW` given it shipped very recently; all four new pages currently carry it.
