### PR TITLE
docs(agent-skills): update skills roster to 17 and refresh Agent Plugin docs

### DIFF
--- a/developer-resources/agent-skills.mdx
+++ b/developer-resources/agent-skills.mdx
@@ -21,16 +21,54 @@ Skills work with any MCP-compatible AI agent, including:
 
 ## Available Skills
 
+Seventeen skills covering the full integration surface, grouped by the task you're working on.
+
+### Getting Started
+
 | Skill | Description |
 |-------|-------------|
-| [dodo-best-practices](https://github.com/dodopayments/skills/tree/main/dodo-payments/best-practices) | Comprehensive guide to integrating Dodo Payments with best practices |
-| [webhook-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/webhook-integration) | Setting up and handling webhooks for payment events |
-| [subscription-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/subscription-integration) | Implementing subscription billing flows |
-| [checkout-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/checkout-integration) | Creating checkout sessions and payment flows |
-| [usage-based-billing](https://github.com/dodopayments/skills/tree/main/dodo-payments/usage-based-billing) | Implementing metered billing with events and meters |
-| [billing-sdk](https://github.com/dodopayments/skills/tree/main/dodo-payments/billing-sdk) | Using BillingSDK React components |
-| [license-keys](https://github.com/dodopayments/skills/tree/main/dodo-payments/license-keys) | Managing license keys for digital products |
-| [credit-based-billing](https://github.com/dodopayments/skills/tree/main/dodo-payments/credit-based-billing) | Implementing credit entitlements, balances, and metered credit deduction |
+| [dodo-best-practices](https://github.com/dodopayments/skills/tree/main/dodo-payments/best-practices) | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
+| [framework-adapters](https://github.com/dodopayments/skills/tree/main/dodo-payments/framework-adapters) | Official `@dodopayments/*` route handlers for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex |
+| [testing-and-go-live](https://github.com/dodopayments/skills/tree/main/dodo-payments/testing-and-go-live) | Test mode, test payment methods, webhook testing, and the production launch checklist |
+
+### Accepting Payments
+
+| Skill | Description |
+|-------|-------------|
+| [checkout-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/checkout-integration) | Checkout Sessions, payment links, and overlay or inline checkout |
+| [subscription-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/subscription-integration) | Subscription lifecycle, trials, plan changes, proration, and on-demand charges |
+| [mobile-checkout](https://github.com/dodopayments/skills/tree/main/dodo-payments/mobile-checkout) | In-app checkout for React Native, Flutter, iOS, and Android |
+| [webhook-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/webhook-integration) | Receiving and verifying webhooks using the Standard Webhooks specification |
+
+### Billing Models
+
+| Skill | Description |
+|-------|-------------|
+| [credit-based-billing](https://github.com/dodopayments/skills/tree/main/dodo-payments/credit-based-billing) | Credit entitlements, balances, ledger, rollover, overage, and meter-based deduction |
+| [usage-based-billing](https://github.com/dodopayments/skills/tree/main/dodo-payments/usage-based-billing) | Meters, event ingestion, aggregation, and per-unit pricing |
+| [license-keys](https://github.com/dodopayments/skills/tree/main/dodo-payments/license-keys) | License key activation, validation, and instance management |
+
+### Catalog and Pricing
+
+| Skill | Description |
+|-------|-------------|
+| [product-catalog-management](https://github.com/dodopayments/skills/tree/main/dodo-payments/product-catalog-management) | Products, pricing, add-ons, collections, images, and digital product delivery |
+| [discounts-and-promotions](https://github.com/dodopayments/skills/tree/main/dodo-payments/discounts-and-promotions) | Discount codes, eligibility rules, stacking, and subscription-cycle limits |
+| [localized-pricing](https://github.com/dodopayments/skills/tree/main/dodo-payments/localized-pricing) | Localized pricing, adaptive currency, and purchasing power parity |
+
+### Customers and Operations
+
+| Skill | Description |
+|-------|-------------|
+| [customer-management](https://github.com/dodopayments/skills/tree/main/dodo-payments/customer-management) | Customers, the self-service portal, saved payment methods, and wallets |
+| [refunds-and-disputes](https://github.com/dodopayments/skills/tree/main/dodo-payments/refunds-and-disputes) | Issuing refunds, handling disputes and chargebacks, and reconciling access |
+
+### UI and Integrations
+
+| Skill | Description |
+|-------|-------------|
+| [billing-sdk](https://github.com/dodopayments/skills/tree/main/dodo-payments/billing-sdk) | BillingSDK React components for pricing tables and billing UI |
+| [better-auth-integration](https://github.com/dodopayments/skills/tree/main/dodo-payments/better-auth-integration) | The `@dodopayments/better-auth` plugin for customer sync, checkout, and portal access |
 
 ## Installation
 
@@ -38,7 +76,7 @@ Choose your preferred installation method based on your AI coding assistant.
 
 <Tabs>
 <Tab title="Agent Plugin (recommended)">
-If you're using Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs all eight skills plus both MCP servers in one step. Skills load automatically when your agent detects a relevant task.
+If you're using Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs all seventeen skills plus both MCP servers in one step. Skills load automatically when your agent detects a relevant task.
 
 See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
 </Tab>
@@ -53,30 +91,35 @@ npx skills add dodopayments/skills
 
 Or install individual skills as needed:
 
-```bash
-# Best practices guide
+```bash expandable
+# Getting started
 npx skills add dodopayments/skills/dodo-payments/best-practices
+npx skills add dodopayments/skills/dodo-payments/framework-adapters
+npx skills add dodopayments/skills/dodo-payments/testing-and-go-live
 
-# Webhook integration
+# Accepting payments
+npx skills add dodopayments/skills/dodo-payments/checkout-integration
+npx skills add dodopayments/skills/dodo-payments/subscription-integration
+npx skills add dodopayments/skills/dodo-payments/mobile-checkout
 npx skills add dodopayments/skills/dodo-payments/webhook-integration
 
-# Subscription billing
-npx skills add dodopayments/skills/dodo-payments/subscription-integration
-
-# Checkout flows
-npx skills add dodopayments/skills/dodo-payments/checkout-integration
-
-# Usage-based billing
+# Billing models
+npx skills add dodopayments/skills/dodo-payments/credit-based-billing
 npx skills add dodopayments/skills/dodo-payments/usage-based-billing
-
-# BillingSDK components
-npx skills add dodopayments/skills/dodo-payments/billing-sdk
-
-# License key management
 npx skills add dodopayments/skills/dodo-payments/license-keys
 
-# Credit-based billing
-npx skills add dodopayments/skills/dodo-payments/credit-based-billing
+# Catalog and pricing
+npx skills add dodopayments/skills/dodo-payments/product-catalog-management
+npx skills add dodopayments/skills/dodo-payments/discounts-and-promotions
+npx skills add dodopayments/skills/dodo-payments/localized-pricing
+
+# Customers and operations
+npx skills add dodopayments/skills/dodo-payments/customer-management
+npx skills add dodopayments/skills/dodo-payments/refunds-and-disputes
+
+# UI and integrations
+npx skills add dodopayments/skills/dodo-payments/billing-sdk
+npx skills add dodopayments/skills/dodo-payments/better-auth-integration
 ```
 
 <Tip>
@@ -93,30 +136,35 @@ Add the Dodo Payments skills marketplace to Claude Code:
 
 Then install individual plugins:
 
-```bash
-# Install best practices
+```bash expandable
+# Getting started
 /plugin install dodo-best-practices
+/plugin install framework-adapters
+/plugin install testing-and-go-live
 
-# Install webhook integration
+# Accepting payments
+/plugin install checkout-integration
+/plugin install subscription-integration
+/plugin install mobile-checkout
 /plugin install webhook-integration
 
-# Install subscription integration
-/plugin install subscription-integration
-
-# Install checkout integration
-/plugin install checkout-integration
-
-# Install usage-based billing
+# Billing models
+/plugin install credit-based-billing
 /plugin install usage-based-billing
-
-# Install BillingSDK
-/plugin install billing-sdk
-
-# Install license keys
 /plugin install license-keys
 
-# Install credit-based billing
-/plugin install credit-based-billing
+# Catalog and pricing
+/plugin install product-catalog-management
+/plugin install discounts-and-promotions
+/plugin install localized-pricing
+
+# Customers and operations
+/plugin install customer-management
+/plugin install refunds-and-disputes
+
+# UI and integrations
+/plugin install billing-sdk
+/plugin install better-auth-integration
 ```
 </Tab>
 
@@ -137,47 +185,27 @@ Skills are automatically available when configured in your OpenCode settings. Ad
 
 ## Using Skills
 
-Once installed, your AI assistant can leverage these skills when you ask it to implement Dodo Payments features. Here are some example prompts:
+Once installed, your AI assistant loads the relevant skill automatically when you ask it to implement a Dodo Payments feature. You don't need to name the skill - just describe the task.
 
-### Best Practices
-```
-Help me integrate Dodo Payments into my Next.js app following best practices
-```
-
-### Webhooks
-```
-Set up webhook handlers for payment and subscription events
-```
-
-### Subscriptions
-```
-Implement a subscription flow with free trial and multiple pricing tiers
-```
-
-### Checkout
-```
-Create a checkout session for my SaaS product
-```
-
-### Usage-Based Billing
-```
-Add usage-based billing to track API calls for my AI product
-```
-
-### BillingSDK
-```
-Add a pricing page using BillingSDK components
-```
-
-### License Keys
-```
-Implement license key validation for my desktop app
-```
-
-### Credit-Based Billing
-```
-Set up credit entitlements and metered credit deduction for my AI product
-```
+| Example prompt | Skill that loads |
+|----------------|------------------|
+| Help me integrate Dodo Payments into my Next.js app following best practices | `dodo-best-practices` |
+| Add a Dodo Payments checkout route handler to my Hono app | `framework-adapters` |
+| Walk me through testing payments and going live | `testing-and-go-live` |
+| Create a checkout session for my SaaS product | `checkout-integration` |
+| Implement a subscription flow with a free trial and multiple pricing tiers | `subscription-integration` |
+| Add in-app checkout to my React Native app | `mobile-checkout` |
+| Set up webhook handlers for payment and subscription events | `webhook-integration` |
+| Set up credit entitlements and metered credit deduction for my AI product | `credit-based-billing` |
+| Add usage-based billing to track API calls for my AI product | `usage-based-billing` |
+| Implement license key validation for my desktop app | `license-keys` |
+| Create a product catalog with add-ons and tiered pricing | `product-catalog-management` |
+| Add a promo code that gives 20% off the first three billing cycles | `discounts-and-promotions` |
+| Show prices in the visitor's local currency with purchasing power parity | `localized-pricing` |
+| Give customers a self-service portal to manage their payment methods | `customer-management` |
+| Issue a partial refund and revoke access when a dispute is opened | `refunds-and-disputes` |
+| Add a pricing page using BillingSDK components | `billing-sdk` |
+| Wire Dodo Payments into my Better Auth setup | `better-auth-integration` |
 
 ## How Skills Work
 

--- a/developer-resources/build-with-ai-coding-agents.mdx
+++ b/developer-resources/build-with-ai-coding-agents.mdx
@@ -6,18 +6,18 @@ icon: "robot"
 keywords: ["Dodo Payments", "AI agent", "Claude Code", "Codex CLI", "Cursor", "OpenCode", "MCP", "coding agent", "agent plugin"]
 ---
 
-The Dodo Agent Plugin wires two MCP servers and eight integration skills into your AI coding agent in a single install. It works with **Claude Code**, **Codex CLI**, **Cursor**, and **OpenCode** — and the MCP servers and skills CLI work with any MCP-compatible client.
+The Dodo Agent Plugin wires two MCP servers and seventeen integration skills into your AI coding agent in a single install. It works with **Claude Code**, **Codex CLI**, **Cursor**, and **OpenCode** — and the MCP servers and skills CLI work with any MCP-compatible client.
 
 <Info>
 **Three primitives, one plugin.** The Agent Plugin bundles everything you need:
 - **API MCP server** — live access to payments, subscriptions, customers, products, refunds, licenses, and usage. Authenticates via browser OAuth (no local keys required).
 - **Knowledge MCP server** — semantic search across all Dodo Payments documentation. No credentials needed.
-- **Eight agent skills** — cheat sheets your agent loads on demand for checkout, subscriptions, webhooks, usage-based billing, credit-based billing, license keys, BillingSDK, and best practices.
+- **Seventeen agent skills** — cheat sheets your agent loads on demand for checkout, subscriptions, webhooks, usage-based and credit-based billing, license keys, product catalog, discounts, localized pricing, mobile checkout, refunds and disputes, customer management, framework adapters, BillingSDK, Better Auth, testing and go-live, and best practices.
 </Info>
 
 ## Install the plugin
 
-Choose your coding agent below. The install adds both MCP servers and all eight skills automatically.
+Choose your coding agent below. The install adds both MCP servers and all seventeen skills automatically.
 
 <AccordionGroup>
 <Accordion title="Claude Code" defaultOpen>
@@ -56,7 +56,7 @@ Then type `/plugins`, switch to the **Dodo Payments** marketplace, select the **
 </Step>
 </Steps>
 
-Both MCP servers and all eight skills are registered automatically once the plugin is installed.
+Both MCP servers and all seventeen skills are registered automatically once the plugin is installed.
 
 <Note>
 Codex CLI does not have a `codex plugin install` subcommand — plugin installation always happens through the in-TUI `/plugins` flow. See the [official Codex plugins docs](https://developers.openai.com/codex/plugins).
@@ -93,7 +93,7 @@ OpenCode distributes via npm. Add the plugin to your `opencode.json`:
 }
 ```
 
-Restart OpenCode. Both MCP servers (`dodopayments-api`, `dodo-knowledge`) are registered automatically via the plugin's config hook, and the eight skills are auto-discovered from the installed package. No manual `mcp` block required.
+Restart OpenCode. Both MCP servers (`dodopayments-api`, `dodo-knowledge`) are registered automatically via the plugin's config hook, and the seventeen skills are auto-discovered from the installed package. No manual `mcp` block required.
 </Accordion>
 </AccordionGroup>
 
@@ -103,7 +103,7 @@ Using a different agent? The [MCP Server](/developer-resources/mcp-server) and [
 
 ## What you get
 
-Once the plugin is installed, your agent has access to two MCP servers and eight skills.
+Once the plugin is installed, your agent has access to two MCP servers and seventeen skills.
 
 ### MCP servers
 
@@ -118,14 +118,23 @@ Both servers are wired through `mcp-remote` so they run in any MCP-compatible cl
 
 | Skill | Description |
 |-------|-------------|
-| `best-practices` | Comprehensive guide to integrating Dodo Payments with best practices |
-| `checkout-integration` | Creating checkout sessions and payment flows |
-| `subscription-integration` | Implementing subscription billing flows |
-| `webhook-integration` | Setting up and handling webhooks for payment events |
-| `usage-based-billing` | Implementing metered billing with events and meters |
-| `credit-based-billing` | Credit entitlements, balances, and metered credit deduction |
-| `license-keys` | Managing license keys for digital products |
-| `billing-sdk` | Using BillingSDK React components |
+| `best-practices` | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
+| `framework-adapters` | Official `@dodopayments/*` route handlers for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex |
+| `testing-and-go-live` | Test mode, test payment methods, webhook testing, and the production launch checklist |
+| `checkout-integration` | Checkout Sessions, payment links, and overlay or inline checkout |
+| `subscription-integration` | Subscription lifecycle, trials, plan changes, proration, and on-demand charges |
+| `mobile-checkout` | In-app checkout for React Native, Flutter, iOS, and Android |
+| `webhook-integration` | Receiving and verifying webhooks using the Standard Webhooks specification |
+| `credit-based-billing` | Credit entitlements, balances, ledger, rollover, overage, and meter-based deduction |
+| `usage-based-billing` | Meters, event ingestion, aggregation, and per-unit pricing |
+| `license-keys` | License key activation, validation, and instance management |
+| `product-catalog-management` | Products, pricing, add-ons, collections, images, and digital product delivery |
+| `discounts-and-promotions` | Discount codes, eligibility rules, stacking, and subscription-cycle limits |
+| `localized-pricing` | Localized pricing, adaptive currency, and purchasing power parity |
+| `customer-management` | Customers, the self-service portal, saved payment methods, and wallets |
+| `refunds-and-disputes` | Issuing refunds, handling disputes and chargebacks, and reconciling access |
+| `billing-sdk` | BillingSDK React components for pricing tables and billing UI |
+| `better-auth-integration` | The `@dodopayments/better-auth` plugin for customer sync, checkout, and portal access |
 
 Skills load automatically — your agent picks the right one when it detects a relevant task. See the [Agent Skills documentation](/developer-resources/agent-skills) for the full list and individual installation.
 
@@ -169,9 +178,15 @@ With the plugin installed, your coding agent can:
 - **Create checkout sessions and payment links** — [One-time payments](/features/one-time-payment-products) and [subscriptions](/features/subscription)
 - **Stand up subscription and usage-based billing end-to-end** — [Subscriptions](/features/subscription), [Usage-based billing](/features/usage-based-billing/introduction), [Credit-based billing](/features/credit-based-billing)
 - **Generate Standard Webhooks–compliant handlers** with signature verification — [Webhooks](/developer-resources/webhooks)
+- **Mount route handlers in your framework** using the official adapters — [Framework adaptors](/developer-resources/framework-adaptors)
 - **Wire BillingSDK React components** for pricing tables and subscription management — [BillingSDK](/developer-resources/billingsdk)
 - **Author license-key flows** for digital products — [License keys](/features/license-keys)
 - **Implement credit-based billing** with entitlements, balances, rollover, and overage — [Credits](/features/credit-based-billing)
+- **Build and manage your product catalog** with add-ons and collections — [Products](/features/products), [Add-ons](/features/addons), [Product collections](/features/product-collections)
+- **Add discounts and localized pricing** — [Discount codes](/features/discount-codes), [Localized pricing](/features/localized-pricing), [Adaptive currency](/features/adaptive-currency)
+- **Ship mobile in-app checkout** for React Native, Flutter, iOS, and Android — [Mobile integration](/developer-resources/mobile-integration)
+- **Handle refunds, disputes, and customer self-service** — [Refunds](/features/transactions/refunds), [Disputes](/features/transactions/disputes), [Customer portal](/features/customer-portal)
+- **Test the integration and go live safely** — [Test mode vs live mode](/miscellaneous/test-mode-vs-live-mode)
 
 ## Security and best practices
 

--- a/developer-resources/mcp-server.mdx
+++ b/developer-resources/mcp-server.mdx
@@ -39,7 +39,7 @@ Connect to the Dodo Payments MCP Server in your AI client:
 
 <Tabs>
 <Tab title="Agent Plugin (recommended)">
-The [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs both MCP servers and all eight skills in one step for Claude Code, Codex CLI, Cursor, and OpenCode. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+The [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs both MCP servers and all seventeen skills in one step for Claude Code, Codex CLI, Cursor, and OpenCode. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
 
 If your agent isn't in that list, use the tabs below to configure the MCP server directly.
 </Tab>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -255,10 +255,10 @@ Enhance your AI coding assistant with official Dodo Payments skills - reusable c
 npx skills add dodopayments/skills
 
 # Or install individual skills
-npx skills add dodopayments/skills/dodo-best-practices
-npx skills add dodopayments/skills/webhook-integration
-npx skills add dodopayments/skills/subscription-integration
-npx skills add dodopayments/skills/credit-based-billing
+npx skills add dodopayments/skills/dodo-payments/best-practices
+npx skills add dodopayments/skills/dodo-payments/webhook-integration
+npx skills add dodopayments/skills/dodo-payments/subscription-integration
+npx skills add dodopayments/skills/dodo-payments/credit-based-billing
 ```
 
 <Info>


### PR DESCRIPTION
## 📋 Description

The [skills repo](https://github.com/dodopayments/skills) now ships **17 skills** (previously 8), and [Dodo Agent Plugin v0.4.0](https://github.com/dodopayments/dodo-agent-plugin/releases/tag/v0.4.0) bundles all of them. The docs still described the old 8-skill roster. This PR brings the English docs in line.

Nine skills are new: `framework-adapters`, `product-catalog-management`, `customer-management`, `refunds-and-disputes`, `discounts-and-promotions`, `localized-pricing`, `mobile-checkout`, `testing-and-go-live`, and `better-auth-integration`. The original eight were rewritten against the current API.

**Changes**

- **`developer-resources/agent-skills.mdx`** — expanded the skills table from 8 to all 17, grouped by task (Getting Started, Accepting Payments, Billing Models, Catalog and Pricing, Customers and Operations, UI and Integrations). Refreshed the Skills CLI and Claude Code install lists. Replaced the eight per-skill `###` prompt sections with a single prompt-to-skill table, which keeps the page readable at 17 entries instead of nearly doubling its length.
- **`developer-resources/build-with-ai-coding-agents.mdx`** — updated the skills table to 17 rows, corrected five stale "eight skills" counts, and extended "What your agent can do" to cover the new areas (catalog, discounts, localized pricing, mobile checkout, refunds and disputes, customer portal, framework adapters, testing and go-live).
- **`developer-resources/mcp-server.mdx`** — corrected the stale "all eight skills" count.
- **`introduction.mdx`** — **bug fix:** the individual skill install commands omitted the `dodo-payments/` directory segment (e.g. `dodopayments/skills/webhook-integration` instead of `dodopayments/skills/dodo-payments/webhook-integration`), so they would not have resolved. The page's skill references were otherwise count-free and needed no changes.

Skill names and descriptions were taken from the merged `marketplace.json` at `dodopayments/skills@8d6ccd9` rather than transcribed by hand.

## 🎯 Type of Change

- [x] 📝 Documentation update (improving existing docs)
- [ ] ✨ New documentation (adding new guides, API docs, etc.)
- [x] 🐛 Bug fix (fixing errors, broken links, incorrect information)
- [ ] 🎨 Style/formatting (improving readability, fixing formatting)
- [ ] 🏗️ Structural change (reorganizing content, navigation updates)
- [ ] 🌐 Translation (adding or improving translations)
- [ ] 🖼️ Assets (adding or updating images, diagrams)

## 📖 What documentation does this PR affect?

- [x] Getting Started / Setup
- [ ] API Reference
- [x] Developer Resources
- [ ] Integration Guides
- [ ] Features Documentation
- [ ] External Integrations
- [ ] Changelog

## ✅ Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have tested my changes locally with `mintlify dev` — see Testing below; the local CLI cannot run on this machine's Node, so `mintlify broken-links` was run under Node 24 instead
- [x] All links are working correctly
- [ ] Images are properly displayed and optimized — no image changes
- [x] Code examples are tested and working — see Testing below
- [x] I have updated the navigation in `docs.json` (if applicable) — not applicable, no pages added or renamed
- [x] My changes follow the project's style guide
- [x] I have performed a self-review of my changes
- [x] I have added appropriate frontmatter to new pages — not applicable, no new pages

## 🧪 Testing

- **`mintlify broken-links` passed repo-wide: "no broken links found."** All 19 internal links referenced in the edited sections were additionally confirmed to resolve to real `.mdx` files, including the 11 newly added ones.
- **Install commands verified against the source of truth.** Every skill path and plugin name was generated from `.claude-plugin/marketplace.json` at the merged skills commit `8d6ccd9`, so the 17 paths and names match the published roster exactly. This is also what surfaced the broken paths in `introduction.mdx`.
- **Translation safety:** the diff touches English source only. Verified no locale directory (`ar cn de es fr hi id it ja ko pt-BR sv vi`), `docs.json`, or `i18n` file is modified — translations are regenerated by the sync workflow.
- **Vale:** not installed locally, but every proper noun introduced (TanStack, Convex, Hono, SvelteKit, Fastify, Better Auth, Flutter, Astro, Remix, Standard Webhooks) already appears in existing English pages, so no vocabulary additions should be required.

Not done: no local `mintlify dev` render or mobile-viewport check. The changes are limited to prose, tables, and fenced code blocks using components already present on these pages, so visual risk is low — but a preview-deploy glance at the two Developer Resources pages would fully close that gap.

## 📝 Additional Notes

The `expandable` prop was added to the two long install code blocks on the Agent Skills page to keep them collapsed by default now that they list 17 commands.

One consistency note for reviewers: the Agent Skills page lists Claude Code plugin names (`dodo-best-practices`), while the Agent Plugin page lists skill directory names (`best-practices`). That split is pre-existing and correct for each context, so I left it as is.

## 👥 Reviewers

@dodopayments/documentation-team
