### PR TITLE
docs(agents): add VS Code, Kiro, Gemini CLI; fix stale agent plugin docs

### DIFF
--- a/developer-resources/agent-skills.mdx
+++ b/developer-resources/agent-skills.mdx
@@ -13,11 +13,18 @@ Agent Skills are reusable capabilities that enhance what AI coding assistants ca
 **Think of skills as plugins for your AI assistant.** They teach your agent how to implement Dodo Payments features correctly, following our recommended patterns and best practices.
 </Info>
 
-Skills work with any MCP-compatible AI agent, including:
+Skills work with any AI agent that supports the skills protocol, including:
 - **Claude Code** - Anthropic's CLI coding assistant
-- **OpenCode** - Open source AI coding agent
+- **Codex CLI** - OpenAI's CLI coding agent
 - **Cursor** - AI-first code editor
-- **Other MCP clients** - Any agent supporting the skills protocol
+- **VS Code / GitHub Copilot** - via the Agent Plugin
+- **Kiro** - loads skills as a Power
+- **OpenCode** - open source AI coding agent
+- **Other clients** - any agent supporting the skills protocol
+
+<Note>
+**Gemini CLI is the exception.** It has no agent-skill primitive, so skills are not available there — only the two [MCP servers](/developer-resources/mcp-server) are.
+</Note>
 
 ## Available Skills
 
@@ -27,7 +34,7 @@ Seventeen skills covering the full integration surface, grouped by the task you'
 
 | Skill | Description |
 |-------|-------------|
-| [dodo-best-practices](https://github.com/dodopayments/skills/tree/main/dodo-payments/best-practices) | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
+| [dodo-best-practices](https://github.com/dodopayments/skills/tree/main/dodo-payments/dodo-best-practices) | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
 | [framework-adapters](https://github.com/dodopayments/skills/tree/main/dodo-payments/framework-adapters) | Official `@dodopayments/*` route handlers for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex |
 | [testing-and-go-live](https://github.com/dodopayments/skills/tree/main/dodo-payments/testing-and-go-live) | Test mode, test payment methods, webhook testing, and the production launch checklist |
 
@@ -76,7 +83,7 @@ Choose your preferred installation method based on your AI coding assistant.
 
 <Tabs>
 <Tab title="Agent Plugin (recommended)">
-If you're using Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs all seventeen skills plus both MCP servers in one step. Skills load automatically when your agent detects a relevant task.
+If you're using Claude Code, Codex CLI, Cursor, VS Code / GitHub Copilot, Kiro, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs all seventeen skills plus both MCP servers in one step. Skills load automatically when your agent detects a relevant task.
 
 See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
 </Tab>
@@ -93,7 +100,7 @@ Or install individual skills as needed:
 
 ```bash expandable
 # Getting started
-npx skills add dodopayments/skills/dodo-payments/best-practices
+npx skills add dodopayments/skills/dodo-payments/dodo-best-practices
 npx skills add dodopayments/skills/dodo-payments/framework-adapters
 npx skills add dodopayments/skills/dodo-payments/testing-and-go-live
 
@@ -169,17 +176,35 @@ Then install individual plugins:
 </Tab>
 
 <Tab title="OpenCode">
-Skills are automatically available when configured in your OpenCode settings. Add the Dodo Payments skills repository to your configuration:
+OpenCode loads skills from directories you point it at. It does **not** scan installed packages, so an explicit `skills.paths` entry is required.
+
+Using the Agent Plugin package:
+
+```bash
+npm install --save-dev @dodopayments/opencode-plugin
+```
 
 ```json
 {
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@dodopayments/opencode-plugin"],
   "skills": {
-    "repositories": [
-      "dodopayments/skills"
-    ]
+    "paths": ["node_modules/@dodopayments/opencode-plugin/skills"]
   }
 }
 ```
+
+Relative paths resolve against the **project directory**, so the package must be present in that project's `node_modules`. An absolute path works too, and avoids the local-install requirement.
+
+<Warning>
+A skills path that does not exist is ignored **silently** — no error, no warning. Confirm the skills actually loaded:
+
+```bash
+opencode run "List every skill available to you by name."
+```
+
+You should see all seventeen.
+</Warning>
 </Tab>
 </Tabs>
 

--- a/developer-resources/build-with-ai-coding-agents.mdx
+++ b/developer-resources/build-with-ai-coding-agents.mdx
@@ -1,12 +1,14 @@
 ---
 title: "Build with AI Coding Agents"
 sidebarTitle: "AI Coding Agents"
-description: "Use the Dodo Agent Plugin to build integrations with Claude Code, Codex CLI, Cursor, and OpenCode — MCP servers and skills in one install."
+description: "Use the Dodo Agent Plugin to build integrations with Claude Code, Codex CLI, Cursor, VS Code, Kiro, Gemini CLI, and OpenCode — MCP servers and skills in one install."
 icon: "robot"
-keywords: ["Dodo Payments", "AI agent", "Claude Code", "Codex CLI", "Cursor", "OpenCode", "MCP", "coding agent", "agent plugin"]
+keywords: ["Dodo Payments", "AI agent", "Claude Code", "Codex CLI", "Cursor", "VS Code", "GitHub Copilot", "Kiro", "Gemini CLI", "OpenCode", "MCP", "coding agent", "agent plugin"]
 ---
 
-The Dodo Agent Plugin wires two MCP servers and seventeen integration skills into your AI coding agent in a single install. It works with **Claude Code**, **Codex CLI**, **Cursor**, and **OpenCode** — and the MCP servers and skills CLI work with any MCP-compatible client.
+The Dodo Agent Plugin wires two MCP servers and seventeen integration skills into your AI coding agent in a single install. It works with **Claude Code**, **Codex CLI**, **Cursor**, **VS Code / GitHub Copilot**, **Kiro**, and **OpenCode**. **Gemini CLI** gets the two MCP servers only. The MCP servers and skills CLI work with any MCP-compatible client.
+
+The plugin follows the [Agent Plugins 1.0.0](https://agent-plugins.org/specification) specification, so clients with native support load it directly from the root `plugin.json` and `mcp.json`. Clients that predate the spec load the same content through generated compatibility manifests.
 
 <Info>
 **Three primitives, one plugin.** The Agent Plugin bundles everything you need:
@@ -17,7 +19,7 @@ The Dodo Agent Plugin wires two MCP servers and seventeen integration skills int
 
 ## Install the plugin
 
-Choose your coding agent below. The install adds both MCP servers and all seventeen skills automatically.
+Choose your coding agent below. Every install adds both MCP servers; all of them except Gemini CLI also add the seventeen skills.
 
 <AccordionGroup>
 <Accordion title="Claude Code" defaultOpen>
@@ -76,11 +78,15 @@ Manual install — clone the repo into Cursor's local plugins directory:
 git clone https://github.com/dodopayments/dodo-agent-plugin.git ~/.cursor/plugins/local/dodo-agent-plugin
 ```
 
-Restart Cursor. The plugin loads skills from `.claude/skills/` (via Cursor's Claude Code compatibility layer) and MCP servers from `.mcp.json`.
+Restart Cursor. The plugin loads skills from `skills/` and MCP servers from `.mcp.json`, as declared in `.cursor-plugin/plugin.json`.
 
 <Info>
-Cursor marketplace support is coming. For now, use the manual install above.
+Recent Cursor builds also recognize Agent Plugins 1.0.0 directly and accept either `.cursor-plugin/marketplace.json` or `.claude-plugin/marketplace.json` as a marketplace source. The generated `.cursor-plugin/plugin.json` is kept for older builds.
 </Info>
+
+<Warning>
+Versions before 0.5.0 shipped `skills/` as symlinks into a git submodule, so this clone produced a plugin with **no working skills**. Skills now ship as real files. If you installed an earlier version, delete the directory and re-clone.
+</Warning>
 </Accordion>
 
 <Accordion title="OpenCode">
@@ -93,12 +99,83 @@ OpenCode distributes via npm. Add the plugin to your `opencode.json`:
 }
 ```
 
-Restart OpenCode. Both MCP servers (`dodopayments-api`, `dodo-knowledge`) are registered automatically via the plugin's config hook, and the seventeen skills are auto-discovered from the installed package. No manual `mcp` block required.
+Restart OpenCode. Both MCP servers (`dodopayments-api`, `dodo-knowledge`) are registered automatically via the plugin's config hook. No manual `mcp` block required.
+
+**Skills need one extra line.** OpenCode does not scan installed packages for skills, so point it at the package's `skills/` directory yourself:
+
+```bash
+npm install --save-dev @dodopayments/opencode-plugin
+```
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["@dodopayments/opencode-plugin"],
+  "skills": {
+    "paths": ["node_modules/@dodopayments/opencode-plugin/skills"]
+  }
+}
+```
+
+Relative `skills.paths` entries resolve against the **project directory**, so the package must exist in that project's `node_modules` — OpenCode's own plugin cache is a different location. An absolute path works too, and avoids the local-install requirement.
+
+<Warning>
+A skills path that does not exist is ignored **silently**. Verify rather than assume:
+
+```bash
+opencode run "List every skill available to you by name."
+```
+
+You should see all seventeen. Versions before 0.5.0 documented these skills as auto-discovered — they were not, so OpenCode users had MCP servers but no skills.
+</Warning>
+</Accordion>
+
+<Accordion title="VS Code / GitHub Copilot">
+Clone the repo anywhere, then register it:
+
+```bash
+git clone https://github.com/dodopayments/dodo-agent-plugin.git
+```
+
+Open the Chat view, go to **Plugins**, and add the cloned folder. You can also register it directly in `settings.json`:
+
+```json
+{
+  "chat.pluginLocations": { "/absolute/path/to/dodo-agent-plugin": true }
+}
+```
+
+The setting is read live, so a running window picks it up without a restart. Skills load from `skills/`, and both MCP servers load from `.mcp.json`.
+
+<Info>
+VS Code does not key off the Agent Plugins `$schema`. Its loader probes `.plugin/plugin.json`, then `.claude-plugin/plugin.json`, then a root `plugin.json`, and defaults MCP to `.mcp.json` rather than `mcp.json`. Because this repo ships a generated `.claude-plugin/plugin.json`, VS Code loads it through that compatibility branch and gets the `mcp-remote` bridge rather than the native transports in `mcp.json`. Everything works — the path differs.
+</Info>
+</Accordion>
+
+<Accordion title="Kiro">
+Kiro reads the Agent Plugins manifest natively and loads this as a Power:
+
+```bash
+git clone https://github.com/dodopayments/dodo-agent-plugin.git
+```
+
+Point Kiro at the cloned folder. Skills load from `skills/`, MCP servers from `mcp.json`, and Kiro-specific presentation comes from the `dev.kiro` extension namespace in `plugin.json`.
+</Accordion>
+
+<Accordion title="Gemini CLI (MCP only)">
+Gemini CLI has no agent-skill primitive, so **only the two MCP servers are available** — the seventeen skills are not. `dodo-knowledge` still covers a good share of what the skills provide, and it stays current automatically.
+
+```bash
+git clone https://github.com/dodopayments/dodo-agent-plugin.git \
+  ~/.gemini/extensions/dodopayments
+```
+
+Restart Gemini CLI. `gemini-extension.json` at the repo root is the manifest.
 </Accordion>
 </AccordionGroup>
 
 <Info>
-Using a different agent? The [MCP Server](/developer-resources/mcp-server) and [Agent Skills](/developer-resources/agent-skills) guides cover Cursor, Claude Desktop, VS Code, Windsurf, Cline, Zed, and any MCP-compatible client.
+Using a different agent? The [MCP Server](/developer-resources/mcp-server) and [Agent Skills](/developer-resources/agent-skills) guides cover Claude Desktop, Windsurf, Cline, Zed, and any MCP-compatible client.
 </Info>
 
 ## What you get
@@ -112,13 +189,13 @@ Once the plugin is installed, your agent has access to two MCP servers and seven
 | `dodopayments-api` | Live API access — payments, subscriptions, customers, products, refunds, licenses, usage | OAuth (browser) |
 | `dodo-knowledge` | Semantic search across all Dodo Payments documentation | None |
 
-Both servers are wired through `mcp-remote` so they run in any MCP-compatible client.
+Both servers speak Streamable HTTP. The canonical `mcp.json` declares them natively (`type: "streamable-http"`), which is what spec-native clients such as Codex CLI, Cursor, and Kiro use. The generated compatibility manifest `.mcp.json` — read by Claude Code and VS Code — wires the same two endpoints through `mcp-remote` instead, so they also run in clients that cannot dial Streamable HTTP directly.
 
 ### Agent skills
 
 | Skill | Description |
 |-------|-------------|
-| `best-practices` | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
+| `dodo-best-practices` | SDK setup, environments, API keys, and the canonical checkout-to-webhook architecture |
 | `framework-adapters` | Official `@dodopayments/*` route handlers for Next.js, Express, Hono, Astro, Remix, SvelteKit, Nuxt, Fastify, TanStack, Bun, and Convex |
 | `testing-and-go-live` | Test mode, test payment methods, webhook testing, and the production launch checklist |
 | `checkout-integration` | Checkout Sessions, payment links, and overlay or inline checkout |
@@ -150,18 +227,20 @@ Your agent will load the `webhook-integration` skill, use the `dodo-knowledge` M
 
 ## Other supported agents
 
-The Agent Plugin covers Claude Code, Codex CLI, Cursor, and OpenCode. If you use a different agent, connect to Dodo Payments through the MCP servers and skills CLI:
+The Agent Plugin covers the clients below. If you use a different agent, connect to Dodo Payments through the MCP servers and skills CLI:
 
-| Agent | Fastest path | Also supports |
-|-------|-------------|---------------|
-| **Claude Code** | Agent Plugin (one command) | MCP server, individual skills |
-| **Codex CLI** | Agent Plugin (one command) | MCP server |
-| **Cursor** | Agent Plugin (git clone) | MCP server config, skills CLI |
-| **OpenCode** | Agent Plugin (npm) | MCP server config, skills CLI |
-| GitHub Copilot (VS Code) | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
-| Claude Desktop | [MCP Server guide](/developer-resources/mcp-server) | — |
-| Windsurf | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
-| Cline / Zed / others | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
+| Agent | Fastest path | Skills | MCP servers |
+|-------|-------------|--------|-------------|
+| **Claude Code** | Agent Plugin (one command) | 17 | 2 |
+| **Codex CLI** | Agent Plugin (marketplace) | 17 | 2 |
+| **Cursor** | Agent Plugin (git clone) | 17 | 2 |
+| **VS Code / GitHub Copilot** | Agent Plugin (git clone) | 17 | 2 |
+| **Kiro** | Agent Plugin (git clone) | 17 | 2 |
+| **OpenCode** | Agent Plugin (npm) | 17, needs `skills.paths` | 2 |
+| **Gemini CLI** | Agent Plugin (git clone) | — no skill primitive | 2 |
+| Claude Desktop | [MCP Server guide](/developer-resources/mcp-server) | — | 2 |
+| Windsurf | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) | 2 |
+| Cline / Zed / others | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) | 2 |
 
 ## Docs built for agents
 

--- a/developer-resources/build-with-ai-coding-agents.mdx
+++ b/developer-resources/build-with-ai-coding-agents.mdx
@@ -81,7 +81,7 @@ git clone https://github.com/dodopayments/dodo-agent-plugin.git ~/.cursor/plugin
 Restart Cursor. The plugin loads skills from `skills/` and MCP servers from `.mcp.json`, as declared in `.cursor-plugin/plugin.json`.
 
 <Info>
-Recent Cursor builds also recognize Agent Plugins 1.0.0 directly and accept either `.cursor-plugin/marketplace.json` or `.claude-plugin/marketplace.json` as a marketplace source. The generated `.cursor-plugin/plugin.json` is kept for older builds.
+Recent Cursor builds also recognize Agent Plugins 1.0.0 directly and accept either `.cursor-plugin/marketplace.json` or `.claude-plugin/marketplace.json` as a marketplace source. This plugin ships `.claude-plugin/marketplace.json` — use that path. The generated `.cursor-plugin/plugin.json` is kept for older builds.
 </Info>
 
 <Warning>
@@ -141,11 +141,15 @@ Open the Chat view, go to **Plugins**, and add the cloned folder. You can also r
 
 ```json
 {
-  "chat.pluginLocations": { "/absolute/path/to/dodo-agent-plugin": true }
+  "chat.pluginLocations": { "~/dodo-agent-plugin": true }
 }
 ```
 
-The setting is read live, so a running window picks it up without a restart. Skills load from `skills/`, and both MCP servers load from `.mcp.json`.
+The key is a path, the value enables it. Absolute paths and `~/` both work; a relative path resolves against each workspace folder. The setting is read live, so a running window picks it up without a restart. Skills load from `skills/`, and both MCP servers load from `.mcp.json`.
+
+<Note>
+`chat.pluginLocations` is marked **experimental** and is a *restricted* setting, so the workspace must be trusted for it to apply. Agent-plugin support overall is a preview feature governed by `chat.plugins.enabled`, which is **on by default** — you only need to set it if your organization disables it by policy.
+</Note>
 
 <Info>
 VS Code does not key off the Agent Plugins `$schema`. Its loader probes `.plugin/plugin.json`, then `.claude-plugin/plugin.json`, then a root `plugin.json`, and defaults MCP to `.mcp.json` rather than `mcp.json`. Because this repo ships a generated `.claude-plugin/plugin.json`, VS Code loads it through that compatibility branch and gets the `mcp-remote` bridge rather than the native transports in `mcp.json`. Everything works — the path differs.
@@ -153,13 +157,29 @@ VS Code does not key off the Agent Plugins `$schema`. Its loader probes `.plugin
 </Accordion>
 
 <Accordion title="Kiro">
-Kiro reads the Agent Plugins manifest natively and loads this as a Power:
+Kiro reads the Agent Plugins manifest natively and loads this as a Power.
 
+<Steps>
+<Step title="Clone the repository">
 ```bash
 git clone https://github.com/dodopayments/dodo-agent-plugin.git
 ```
+</Step>
 
-Point Kiro at the cloned folder. Skills load from `skills/`, MCP servers from `mcp.json`, and Kiro-specific presentation comes from the `dev.kiro` extension namespace in `plugin.json`.
+<Step title="Open the Powers panel">
+In Kiro, open the Powers panel — the Ghosty icon with the lightning bolt.
+</Step>
+
+<Step title="Import the folder">
+Choose **Add Custom Power → Import power from a folder**, select the cloned directory (the one containing `plugin.json`), and click **Install**.
+</Step>
+</Steps>
+
+Skills load from `skills/`, MCP servers from `mcp.json`, and Kiro-specific presentation comes from the `dev.kiro` extension namespace in `plugin.json`.
+
+<Note>
+For plugins in the Agent Plugins format, Kiro manages MCP servers internally — they are **not** written to your user-level `~/.kiro/settings/mcp.json`, so don't expect to find them there. Kiro can also install a Power directly from a GitHub URL; see [Kiro's install docs](https://kiro.dev/docs/powers/installation/).
+</Note>
 </Accordion>
 
 <Accordion title="Gemini CLI (MCP only)">
@@ -189,7 +209,7 @@ Once the plugin is installed, your agent has access to two MCP servers and seven
 | `dodopayments-api` | Live API access — payments, subscriptions, customers, products, refunds, licenses, usage | OAuth (browser) |
 | `dodo-knowledge` | Semantic search across all Dodo Payments documentation | None |
 
-Both servers speak Streamable HTTP. The canonical `mcp.json` declares them natively (`type: "streamable-http"`), which is what spec-native clients such as Codex CLI, Cursor, and Kiro use. The generated compatibility manifest `.mcp.json` — read by Claude Code and VS Code — wires the same two endpoints through `mcp-remote` instead, so they also run in clients that cannot dial Streamable HTTP directly.
+Both servers speak Streamable HTTP. The canonical `mcp.json` declares them natively (`type: "streamable-http"`), which is what spec-native clients such as Codex CLI and Kiro use. The generated compatibility manifest `.mcp.json` wires the same two endpoints through `mcp-remote` instead, so they also run in clients that cannot dial Streamable HTTP directly — Claude Code, VS Code, and Cursor via the git-clone install documented above, whose `.cursor-plugin/plugin.json` points at `.mcp.json`.
 
 ### Agent skills
 
@@ -225,22 +245,34 @@ Set up Dodo Payments webhook handlers in my Next.js app for payment.succeeded an
 
 Your agent will load the `webhook-integration` skill, use the `dodo-knowledge` MCP to pull the latest payload shapes, and write a handler with signature verification following the Standard Webhooks spec.
 
-## Other supported agents
+## Client support
 
-The Agent Plugin covers the clients below. If you use a different agent, connect to Dodo Payments through the MCP servers and skills CLI:
+### Clients with an Agent Plugin install
 
-| Agent | Fastest path | Skills | MCP servers |
-|-------|-------------|--------|-------------|
-| **Claude Code** | Agent Plugin (one command) | 17 | 2 |
-| **Codex CLI** | Agent Plugin (marketplace) | 17 | 2 |
-| **Cursor** | Agent Plugin (git clone) | 17 | 2 |
-| **VS Code / GitHub Copilot** | Agent Plugin (git clone) | 17 | 2 |
-| **Kiro** | Agent Plugin (git clone) | 17 | 2 |
-| **OpenCode** | Agent Plugin (npm) | 17, needs `skills.paths` | 2 |
-| **Gemini CLI** | Agent Plugin (git clone) | — no skill primitive | 2 |
-| Claude Desktop | [MCP Server guide](/developer-resources/mcp-server) | — | 2 |
-| Windsurf | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) | 2 |
-| Cline / Zed / others | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) | 2 |
+One install wires both MCP servers, plus the skills on every client that has a skill primitive.
+
+| Agent | Install | Skills | MCP servers |
+|-------|---------|-------:|------------:|
+| **Claude Code** | marketplace command | 17 | 2 |
+| **Codex CLI** | marketplace command | 17 | 2 |
+| **Cursor** | git clone | 17 | 2 |
+| **VS Code / GitHub Copilot** | git clone | 17 | 2 |
+| **Kiro** | git clone | 17 | 2 |
+| **OpenCode** | npm | 17 | 2 |
+| **Gemini CLI** | git clone | 0 | 2 |
+
+- **OpenCode** needs one extra `skills.paths` entry before its seventeen skills load — see the install section above.
+- **Gemini CLI** has no agent-skill primitive, so skills are unavailable there by design.
+
+### Other MCP-compatible clients
+
+These have no Agent Plugin install. Configure the two MCP servers by hand, and add skills through the Skills CLI where supported.
+
+| Agent | MCP servers | Skills |
+|-------|-------------|--------|
+| Claude Desktop | [MCP Server guide](/developer-resources/mcp-server) | not supported |
+| Windsurf | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
+| Cline / Zed / others | [MCP Server guide](/developer-resources/mcp-server) | [Skills CLI](/developer-resources/agent-skills) |
 
 ## Docs built for agents
 

--- a/developer-resources/mcp-server.mdx
+++ b/developer-resources/mcp-server.mdx
@@ -39,7 +39,7 @@ Connect to the Dodo Payments MCP Server in your AI client:
 
 <Tabs>
 <Tab title="Agent Plugin (recommended)">
-The [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs both MCP servers and all seventeen skills in one step for Claude Code, Codex CLI, Cursor, and OpenCode. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+The [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) installs both MCP servers and all seventeen skills in one step for Claude Code, Codex CLI, Cursor, VS Code / GitHub Copilot, Kiro, and OpenCode. Gemini CLI gets the two MCP servers only, since it has no agent-skill primitive. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
 
 If your agent isn't in that list, use the tabs below to configure the MCP server directly.
 </Tab>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -68,7 +68,7 @@ Get up and running with Dodo Payments in just a few steps.
 <Accordion title="For AI Agents">
   Dodo Payments is built for agent-native workflows. If you're an LLM reading this - or a developer configuring one - start here.
 
-  **Install**. For Claude Code, Codex CLI, Cursor, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) wires both MCP servers and all skills in one step. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
+  **Install**. For Claude Code, Codex CLI, Cursor, VS Code / GitHub Copilot, Kiro, or OpenCode, the [Dodo Agent Plugin](/developer-resources/build-with-ai-coding-agents) wires both MCP servers and all skills in one step. Gemini CLI gets the MCP servers only. See the [AI Coding Agents guide](/developer-resources/build-with-ai-coding-agents) for per-agent install commands.
 
   **Discover**. The full docs index is served at [`docs.dodopayments.com/llms.txt`](https://docs.dodopayments.com/llms.txt), and every documentation page is available in plain markdown by appending `.md` to its URL (e.g. `/api-reference/introduction.md`).
 
@@ -85,7 +85,7 @@ Get up and running with Dodo Payments in just a few steps.
   npx skills add dodopayments/skills
   ```
 
-  Works with Claude Code, OpenCode, Cursor, and any MCP-compatible agent.
+  Works with Claude Code, Codex CLI, Cursor, VS Code / GitHub Copilot, Kiro, OpenCode, and any agent supporting the skills protocol.
 </Accordion>
 </AccordionGroup>
 
@@ -202,11 +202,11 @@ Get up and running with Dodo Payments in just a few steps.
 
 ### Build with AI Coding Agents
 
-Connect your AI coding assistant (Claude Code, Codex CLI, Cursor, OpenCode, Windsurf, VS Code) directly to Dodo Payments — install the Agent Plugin for a one-command setup, or connect the MCP servers manually.
+Connect your AI coding assistant directly to Dodo Payments. The Agent Plugin is a one-command setup for Claude Code, Codex CLI, Cursor, VS Code / GitHub Copilot, Kiro, and OpenCode. Other MCP-compatible agents such as Windsurf, Claude Desktop, Cline, and Zed connect through the MCP servers manually.
 
 <CardGroup cols={3}>
 <Card title="Agent Plugin" icon="robot" href="/developer-resources/build-with-ai-coding-agents">
-  One install bundles both MCP servers and all skills for Claude Code, Codex CLI, Cursor, and OpenCode
+  One install bundles both MCP servers and all seventeen skills for Claude Code, Codex CLI, Cursor, VS Code, Kiro, and OpenCode
 </Card>
 
 <Card title="Dodo Knowledge MCP" icon="book-open" href="/developer-resources/mcp-server#dodo-knowledge-mcp">
@@ -255,7 +255,7 @@ Enhance your AI coding assistant with official Dodo Payments skills - reusable c
 npx skills add dodopayments/skills
 
 # Or install individual skills
-npx skills add dodopayments/skills/dodo-payments/best-practices
+npx skills add dodopayments/skills/dodo-payments/dodo-best-practices
 npx skills add dodopayments/skills/dodo-payments/webhook-integration
 npx skills add dodopayments/skills/dodo-payments/subscription-integration
 npx skills add dodopayments/skills/dodo-payments/credit-based-billing

--- a/styles/config/vocabularies/Mintlify/accept.txt
+++ b/styles/config/vocabularies/Mintlify/accept.txt
@@ -212,6 +212,7 @@ Futuna
 gameplay
 GCP
 Gemfile
+Ghosty
 Git
 git
 GitHub

--- a/styles/config/vocabularies/Mintlify/accept.txt
+++ b/styles/config/vocabularies/Mintlify/accept.txt
@@ -291,6 +291,7 @@ Karne
 Kazakhstani
 Keplars
 keyloggers
+Kiro
 Kitts
 Klarna
 Knab
@@ -360,6 +361,7 @@ myName
 myObject
 mypy
 MySQL
+namespace
 nav
 Naver
 Nederlands
@@ -554,6 +556,7 @@ stdin
 stdout
 Storybook
 str
+Streamable
 Strikethrough
 stringified
 struct


### PR DESCRIPTION
Extends the Agent Plugin docs to every client supported by plugin **v0.5.0**, and corrects several statements that no longer hold. English source only — no locale directories or `i18n.lock` touched, per `AGENTS.md`.

## New client support

| Client | Skills | MCP servers |
|---|---|---|
| **VS Code / GitHub Copilot** | 17 | 2 |
| **Kiro** | 17 | 2 |
| **Gemini CLI** | — no skill primitive | 2 |

Gemini CLI is documented as **MCP-only** everywhere it appears. It has no agent-skill primitive, so the seventeen skills genuinely are not available there — worth stating explicitly rather than lumping it in with the rest.

The "Other supported agents" matrix now reports skills and MCP counts per client, and VS Code moves out of the MCP-only bucket into the plugin rows.

## Corrections (these were wrong, not just incomplete)

**OpenCode skills were documented as auto-discovered.** They are not — nothing in OpenCode scans an installed package, so anyone following the old docs got MCP servers and zero skills. Now documents the required `skills.paths` entry, that relative paths resolve against the *project* directory (not OpenCode's plugin cache), and that a non-existent path is ignored **silently**, with a verification command.

**Three links returned HTTP 404.** The upstream skill directory was renamed `best-practices` → `dodo-best-practices`. Confirmed empirically: old path `404`, new path `200`.

**Cursor.** Skills load from `skills/` as declared in `.cursor-plugin/plugin.json` — not from `.claude/skills/` "via Cursor's Claude Code compatibility layer". Also dropped the stale "marketplace support is coming" note.

**MCP transport.** Canonical `mcp.json` declares both servers as native `streamable-http`; only the generated `.mcp.json` compat manifest uses the `mcp-remote` bridge. The page claimed everything went through `mcp-remote`.

**`introduction.mdx` contradicted itself** — prose listed six clients as getting one-command setup while the card directly beneath it named four.

**`agent-skills.mdx` OpenCode tab** documented a `skills.repositories` config key. I could find no evidence that key exists; replaced with the `skills.paths` mechanism that I verified working.

## Verification

- `vale .` on all four pages: **0 errors** (added `Kiro`, `Streamable`, `namespace` to the Mintlify vocabulary; reworded "vendored" rather than expanding the allowlist further).
- All **23** internal links in the changed pages resolve on disk; new external links return 200.
- Client behaviour claims are from runtime checks against the plugin: Codex 0.147.0 (bare clone, 17 skills / 2 MCPs), OpenCode 1.18.15, Cursor 3.14.27 (17/17), VS Code 1.125.1 (both MCP servers).

## Notes for the reviewer

- `mintlify broken-links` could not run here — it rejects Node 25+, and on Node 24 the subcommand produced no output and exited 1. The link check above was done manually instead, so a CI/preview link check is still worth trusting over my word.
- **Out of scope, flagged for follow-up:** 11 English lines still point at `https://mcp.dodopayments.com/sse` while the plugin has moved to `/mcp`. Both endpoints currently return 401 (an auth challenge, so `/sse` is still live and those configs still work), and one of the 11 is a historical changelog entry that should not be rewritten. It seemed wrong to bundle an endpoint migration into a client-support PR.