### PR TITLE
fix(docs): remove Android API key example

### DIFF
--- a/developer-resources/sdks/kotlin.mdx
+++ b/developer-resources/sdks/kotlin.mdx
@@ -351,35 +351,20 @@ safeCreatePayment(client)
 Use Kotlin's `runCatching` for a more functional approach to error handling with Result types.
 </Tip>
 
-## Android Integration
+## Android Applications
 
-Use with Android applications:
+The Kotlin SDK is for server-side integrations. Do not initialize it from an Android app or include a Dodo Payments API key in your app, including through `BuildConfig`. Android app binaries can expose bundled API keys.
 
-```kotlin
-import android.app.Application
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.dodopayments.api.client.DodoPaymentsClient
-import kotlinx.coroutines.launch
+Create checkout sessions on your backend with this SDK, then return the `checkout_url` to your Android app. Open that URL with the [Android Checkout SDK](/developer-resources/sdks/android), which does not require an API key.
 
-class PaymentViewModel(application: Application) : ViewModel() {
-    private val client = DodoPaymentsOkHttpClient.builder()
-        .bearerToken(BuildConfig.DODO_API_KEY)
-        .build()
-    
-    fun createCheckout(productId: String) {
-        viewModelScope.launch {
-            try {
-                val session = client.async().checkoutSessions().create(params)
-                // Open checkout URL in browser or WebView
-                openUrl(session.checkoutUrl())
-            } catch (e: Exception) {
-                handleError(e)
-            }
-        }
-    }
-}
-```
+<CardGroup cols={2}>
+  <Card title="Create a Checkout Session" icon="cart-shopping" href="/developer-resources/checkout-session">
+    Create checkout sessions securely from your backend.
+  </Card>
+  <Card title="Android Checkout SDK" icon="android" href="/developer-resources/sdks/android">
+    Open a backend-provided checkout URL in your Android app.
+  </Card>
+</CardGroup>
 
 ## Response Validation
 


### PR DESCRIPTION
## Description

Removes the Kotlin SDK's unsafe Android example that initialized a server-side Dodo Payments client with `BuildConfig.DODO_API_KEY`. API keys bundled into Android binaries can be recovered, and checkout sessions must be created by the application's backend.

The replacement makes the server/mobile boundary explicit and directs readers to create checkout sessions on the backend, then open the returned `checkout_url` with the Android Checkout SDK.

## Type of Change

- [x] 📝 Documentation update (improving existing docs)
- [x] 🐛 Bug fix (fixing errors, broken links, incorrect information)

## What documentation does this PR affect?

- [x] Developer Resources

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] My changes follow the project's style guide
- [x] I have performed a self-review of my changes

## Testing

- [x] `mint validate --telemetry false`
- [x] Confirmed the two new internal targets exist locally:
  - `/developer-resources/checkout-session`
  - `/developer-resources/sdks/android`
- [ ] The repository-wide `mint broken-links` command currently reports 7,520 pre-existing broken links across 1,748 files, so it cannot provide a clean repository-level signal for this isolated change.

## Related Issues

Closes #450

## Additional Notes

This keeps the change focused on the contradictory Android section in the Kotlin SDK guide. No navigation changes or new pages are required.